### PR TITLE
move get_similar_account_names from Account to Blockchain + Wallet DRY

### DIFF
--- a/beem/account.py
+++ b/beem/account.py
@@ -215,29 +215,20 @@ class Account(BlockchainObject):
         return self.get_similar_account_names(limit=limit)
 
     def get_similar_account_names(self, limit=5):
-        """ Returns limit similar accounts with name as list
+        """ Returns ``limit`` account names similar to the current account
+            name as a list
 
-        :param int limit: limits the number of accounts, which will be returned
-        :returns: Similar account names as list
-        :rtype: list
+            :param int limit: limits the number of accounts, which will be
+                returned
+            :returns: Similar account names as list
+            :rtype: list
 
-        .. code-block:: python
-
-            >>> from beem.account import Account
-            >>> account = Account("test")
-            >>> len(account.get_similar_account_names(limit=5))
-            5
+            This is a wrapper around ``Blockchain.get_similar_account_names()``
+            using the current account name as reference.
 
         """
-        if not self.steem.is_connected():
-            return None
-        self.steem.rpc.set_next_node_on_empty_reply(False)
-        if self.steem.rpc.get_use_appbase():
-            account = self.steem.rpc.list_accounts({'start': self.name, 'limit': limit}, api="database")
-            if bool(account):
-                return account["accounts"]
-        else:
-            return self.steem.rpc.lookup_accounts(self.name, limit)
+        b = Blockchain(steem_instance=self.steem)
+        return b.get_similar_account_names(self.name, limit=limit)
 
     @property
     def name(self):

--- a/beem/blockchain.py
+++ b/beem/blockchain.py
@@ -847,3 +847,29 @@ class Blockchain(object):
             lastname = account_name
             if len(ret) < steps:
                 raise StopIteration
+
+    def get_similar_account_names(self, name, limit=5):
+        """ Returns limit similar accounts with name as list
+
+        :param str name: account name to search similars for
+        :param int limit: limits the number of accounts, which will be returned
+        :returns: Similar account names as list
+        :rtype: list
+
+        .. code-block:: python
+
+            >>> from beem.blockchain import Blockchain
+            >>> blockchain = Blockchain()
+            >>> blockchain.get_similar_account_names("test", limit=5)
+            ['test', 'test-1', 'test-2', 'test-ico', 'test-ilionx-123']
+
+        """
+        if not self.steem.is_connected():
+            return None
+        self.steem.rpc.set_next_node_on_empty_reply(False)
+        if self.steem.rpc.get_use_appbase():
+            account = self.steem.rpc.list_accounts({'start': name, 'limit': limit}, api="database")
+            if bool(account):
+                return account["accounts"]
+        else:
+            return self.steem.rpc.lookup_accounts(name, limit)

--- a/beem/wallet.py
+++ b/beem/wallet.py
@@ -580,7 +580,9 @@ class Wallet(object):
         return self.getAccountFromPublicKey(pub)
 
     def getAccountsFromPublicKey(self, pub):
-        """ Obtain all accounts associated with a public key
+        """ Obtain all account names associated with a public key
+
+            :param str pub: Public key
         """
         if not self.steem.is_connected():
             raise OfflineHasNoRPCException("No RPC available in offline mode!")
@@ -595,14 +597,14 @@ class Wallet(object):
 
     def getAccountFromPublicKey(self, pub):
         """ Obtain the first account name from public key
+
+            :param str pub: Public key
+
+            Note: this returns only the first account with the given key. To
+            get all accounts associated with a given public key, use
+            ``getAccountsFromPublicKey``.
         """
-        # FIXME, this only returns the first associated key.
-        # If the key is used by multiple accounts, this
-        # will surely lead to undesired behavior
-        if self.rpc.get_use_appbase():
-            names = self.rpc.get_key_references({'keys': [pub]}, api="account_by_key")["accounts"][0]
-        else:
-            names = self.rpc.get_key_references([pub], api="account_by_key")[0]
+        names = list(self.getAccountsFromPublicKey(pub))
         if not names:
             return None
         else:
@@ -611,6 +613,8 @@ class Wallet(object):
     def getAllAccounts(self, pub):
         """ Get the account data for a public key (all accounts found for this
             public key)
+
+            :param str pub: Public key
         """
         for name in self.getAccountsFromPublicKey(pub):
             try:
@@ -625,6 +629,8 @@ class Wallet(object):
     def getAccount(self, pub):
         """ Get the account data for a public key (first account found for this
             public key)
+
+            :param str pub: Public key
         """
         name = self.getAccountFromPublicKey(pub)
         if not name:
@@ -641,6 +647,10 @@ class Wallet(object):
 
     def getKeyType(self, account, pub):
         """ Get key type
+
+            :param beem.account.Account/dict account: Account data
+            :param str pub: Public key
+
         """
         for authority in ["owner", "active", "posting"]:
             for key in account[authority]["key_auths"]:


### PR DESCRIPTION
* `Account.get_similar_account_names()`: The underlying RPC call searches for account names that are similar to the given chars. So typically one would want to run this with the first few characters of an account name. Running it with "crok" would eventually also return "crokkon". But by having this in `Account` requires the account `crok` to exist in order to be able to use this function at all. Moving the main function to `Blockchain` like `get_all_accounts()` etc. makes this usable also without a valid user name. A wrapper around this in `Account` keeps backwards compatibility to the previous implementation.
* `Wallet`: the same RPC call was implemented twice for `getAccountFormPulicKey()` and `getAccountsFormPulicKey()` - removing some redundancy by using the existing `getAccountsFormPulicKey` in `getAccountFormPulicKey`