### PR TITLE
Added an example to the custom_json section for documentation.

### DIFF
--- a/beem/steem.py
+++ b/beem/steem.py
@@ -1206,6 +1206,14 @@ class Steem(object):
             :param list required_auths: (optional) required auths
             :param list required_posting_auths: (optional) posting auths
 
+            Note: While reqired auths and required_posting_auths are both
+            optional, one of the two are needed in order to send the custom
+            json.
+
+            .. code-block:: python
+               steem.custom_json("id", "json_data",
+               required_posting_auths=['account']) 
+
         """
         account = None
         if len(required_auths):


### PR DESCRIPTION
It was slightly unclear that one of the two required auths were needed since both also say optional. Added a note explaining the need for one of the two as well as a block of pseudocode to display the message further.