### PR TITLE
Add get_vote_pct_for_SBD, sbd_to_vote_pct and sbd_to_rshares

### DIFF
--- a/beem/account.py
+++ b/beem/account.py
@@ -372,7 +372,7 @@ class Account(BlockchainObject):
         VoteValue = self.steem.sp_to_sbd(sp, voting_power=voting_power * 100, vote_pct=voting_weight * 100, not_broadcasted_vote=not_broadcasted_vote)
         return VoteValue
 
-    def get_vote_pct_for_SBD(self, sbd, voting_power=None, steem_power=None):
+    def get_vote_pct_for_SBD(self, sbd, voting_power=None, steem_power=None, not_broadcasted_vote=True):
         """ Returns the voting percentage needed to have a vote worth a given number of SBD.
 
             If the returned number is bigger than 10000 or smaller than -10000,
@@ -395,7 +395,7 @@ class Account(BlockchainObject):
         if sbd['symbol'] != 'SBD':
             raise AssertionError('Should input SBD, not any other asset!')
 
-        vote_pct = self.steem.rshares_to_vote_pct(self.steem.sbd_to_rshares(sbd), voting_power=voting_power * 100, steem_power=steem_power)
+        vote_pct = self.steem.rshares_to_vote_pct(self.steem.sbd_to_rshares(sbd, not_broadcasted_vote=not_broadcasted_vote), voting_power=voting_power * 100, steem_power=steem_power)
         return vote_pct
 
     def get_creator(self):

--- a/beem/account.py
+++ b/beem/account.py
@@ -387,11 +387,11 @@ class Account(BlockchainObject):
             steem_power = self.get_steem_power()
 
         if isinstance(sbd, Amount):
-            sbd = Amount(sbd, steem_instance=self)
+            sbd = Amount(sbd, steem_instance=self.steem)
         elif isinstance(sbd, string_types):
-            sbd = Amount(sbd, steem_instance=self)
+            sbd = Amount(sbd, steem_instance=self.steem)
         else:
-            sbd = Amount(sbd, 'SBD', steem_instance=self)
+            sbd = Amount(sbd, 'SBD', steem_instance=self.steem)
         if sbd['symbol'] != 'SBD':
             raise AssertionError('Should input SBD, not any other asset!')
 

--- a/beem/account.py
+++ b/beem/account.py
@@ -377,6 +377,15 @@ class Account(BlockchainObject):
             voting_power = self.get_voting_power()
         if steem_power is None:
             steem_power = self.get_steem_power()
+        if isinstance(sbd, Amount):
+            sbd = Amount(sbd, steem_instance=self)
+        elif isinstance(sbd, string_types):
+            sbd = Amount(sbd, steem_instance=self)
+        else:
+            sbd = Amount(sbd, 'SBD', steem_instance=self)
+        if sbd['symbol'] != 'SBD':
+            raise AssertionError('Should input SBD, not any other currency!')
+
 
         vote_pct = self.steem.rshares_to_vote_pct(self.steem.sbd_to_rshares(sbd), voting_power=voting_power * 100, steem_power=steem_power)
         return vote_pct

--- a/beem/account.py
+++ b/beem/account.py
@@ -372,6 +372,15 @@ class Account(BlockchainObject):
         VoteValue = self.steem.sp_to_sbd(sp, voting_power=voting_power * 100, vote_pct=voting_weight * 100, not_broadcasted_vote=not_broadcasted_vote)
         return VoteValue
 
+    def get_vote_pct_for_SBD(self, sbd, voting_power=None, steem_power=None):
+        if voting_power is None:
+            voting_power = self.get_voting_power()
+        if steem_power is None:
+            steem_power = self.get_steem_power()
+
+        vote_pct = self.steem.rshares_to_vote_pct(self.steem.sbd_to_rshares(sbd), voting_power=voting_power * 100, steem_power=steem_power)
+        return vote_pct
+
     def get_creator(self):
         """ Returns the account creator or `None` if the account was mined
         """

--- a/beem/account.py
+++ b/beem/account.py
@@ -373,6 +373,12 @@ class Account(BlockchainObject):
         return VoteValue
 
     def get_vote_pct_for_SBD(self, sbd, voting_power=None, steem_power=None):
+        """ Returns the voting percentage needed to have a vote worth a given number of SBD.
+
+            If the retuned number is bigger than 10000 or smaller than -10000,
+            the given SBD value is too high for that account
+
+            :param amount sbd: The amount of SBD in vote value"""
         if voting_power is None:
             voting_power = self.get_voting_power()
         if steem_power is None:

--- a/beem/account.py
+++ b/beem/account.py
@@ -375,14 +375,17 @@ class Account(BlockchainObject):
     def get_vote_pct_for_SBD(self, sbd, voting_power=None, steem_power=None):
         """ Returns the voting percentage needed to have a vote worth a given number of SBD.
 
-            If the retuned number is bigger than 10000 or smaller than -10000,
+            If the returned number is bigger than 10000 or smaller than -10000,
             the given SBD value is too high for that account
 
-            :param amount sbd: The amount of SBD in vote value"""
+            :param str/int/Amount sbd: The amount of SBD in vote value
+
+        """
         if voting_power is None:
             voting_power = self.get_voting_power()
         if steem_power is None:
             steem_power = self.get_steem_power()
+
         if isinstance(sbd, Amount):
             sbd = Amount(sbd, steem_instance=self)
         elif isinstance(sbd, string_types):
@@ -390,8 +393,7 @@ class Account(BlockchainObject):
         else:
             sbd = Amount(sbd, 'SBD', steem_instance=self)
         if sbd['symbol'] != 'SBD':
-            raise AssertionError('Should input SBD, not any other currency!')
-
+            raise AssertionError('Should input SBD, not any other asset!')
 
         vote_pct = self.steem.rshares_to_vote_pct(self.steem.sbd_to_rshares(sbd), voting_power=voting_power * 100, steem_power=steem_power)
         return vote_pct

--- a/beem/steem.py
+++ b/beem/steem.py
@@ -575,7 +575,9 @@ class Steem(object):
     def sbd_to_rshares(self, sbd, use_stored_data=True):
         """ Obtain the r-shares from SBD
 
-        :param amount sbd: SBD"""
+        :param amount sbd: SBD
+
+        """
         if isinstance(sbd, Amount):
             sbd = Amount(sbd, steem_instance=self)
         elif isinstance(sbd, string_types):
@@ -583,9 +585,8 @@ class Steem(object):
         else:
             sbd = Amount(sbd, 'SBD', steem_instance=self)
         if sbd['symbol'] != 'SBD':
-            raise AssertionError('Should input SBD, not any other currency!')
+            raise AssertionError('Should input SBD, not any other asset!')
         return int(sbd.amount / self.get_sbd_per_rshares(use_stored_data=use_stored_data))
-
 
     def rshares_to_vote_pct(self, rshares, steem_power=None, vests=None, voting_power=STEEM_100_PERCENT, use_stored_data=True):
         """ Obtain the voting percentage for a desired rshares value
@@ -619,16 +620,18 @@ class Steem(object):
 
     def sbd_to_vote_pct(self, sbd, steem_power=None, vests=None, voting_power=STEEM_100_PERCENT, use_stored_data=True):
         """ Obtain the voting percentage for a desired SBD value
-                    for a given Steem Power or vesting shares and voting power
-                    Give either Steem Power or vests, not both.
-                    When the output is greater than 10000 or smaller than -10000,
-                    the SBD value is too high.
+            for a given Steem Power or vesting shares and voting power
+            Give either Steem Power or vests, not both.
+            When the output is greater than 10000 or smaller than -10000,
+            the SBD value is too high.
 
-                    Returns the required voting percentage (100% = 10000)
+            Returns the required voting percentage (100% = 10000)
 
-                    :param amount sbd: desired SBD value
-                    :param number steem_power: Steem Power
-                    :param number vests: vesting shares"""
+            :param str/int/Amount sbd: desired SBD value
+            :param number steem_power: Steem Power
+            :param number vests: vesting shares
+
+        """
         if isinstance(sbd, Amount):
             sbd = Amount(sbd, steem_instance=self)
         elif isinstance(sbd, string_types):

--- a/beem/steem.py
+++ b/beem/steem.py
@@ -580,7 +580,7 @@ class Steem(object):
         else:
             sbd = Amount(sbd, 'SBD', steem_instance=self)
         if sbd['symbol'] != 'SBD':
-            raise AssertionError()
+            raise AssertionError('Should input SBD, not any other currency!')
         return int(sbd.amount / self.get_sbd_per_rshares(use_stored_data=use_stored_data))
 
 

--- a/beem/steem.py
+++ b/beem/steem.py
@@ -575,7 +575,10 @@ class Steem(object):
     def sbd_to_rshares(self, sbd, not_broadcasted_vote=False, precision_iterations=10, use_stored_data=True):
         """ Obtain the r-shares from SBD
 
-        :param amount sbd: SBD
+        :param Amount sbd: SBD
+        :param int precision_iterations: This is needed for making the calculation more precise.
+         The higher the number, the bigger the computational effort needed. It gets automatically adjusted
+         normally.
 
         """
         if isinstance(sbd, Amount):

--- a/beem/steem.py
+++ b/beem/steem.py
@@ -572,6 +572,18 @@ class Steem(object):
         rshares = int(math.copysign(vests * 1e6 * used_power / STEEM_100_PERCENT, vote_pct))
         return rshares
 
+    def sbd_to_rshares(self, sbd, use_stored_data=True):
+        if isinstance(sbd, Amount):
+            sbd = Amount(sbd, steem_instance=self)
+        elif isinstance(sbd, string_types):
+            sbd = Amount(sbd, steem_instance=self)
+        else:
+            sbd = Amount(sbd, 'SBD', steem_instance=self)
+        if sbd['symbol'] != 'SBD':
+            raise AssertionError()
+        return int(sbd.amount / self.get_sbd_per_rshares(use_stored_data=use_stored_data))
+
+
     def rshares_to_vote_pct(self, rshares, steem_power=None, vests=None, voting_power=STEEM_100_PERCENT, use_stored_data=True):
         """ Obtain the voting percentage for a desired rshares value
             for a given Steem Power or vesting shares and voting_power

--- a/beem/steem.py
+++ b/beem/steem.py
@@ -615,6 +615,17 @@ class Steem(object):
         return int(math.copysign(vote_pct, rshares))
 
     def sbd_to_vote_pct(self, sbd, steem_power=None, vests=None, voting_power=STEEM_100_PERCENT, use_stored_data=True):
+        """ Obtain the voting percentage for a desired SBD value
+                    for a given Steem Power or vesting shares and voting power
+                    Give either Steem Power or vests, not both.
+                    When the output is greater than 10000 or smaller than -10000,
+                    the SBD value is too high.
+
+                    Returns the required voting percentage (100% = 10000)
+
+                    :param amount sbd: desired SBD value
+                    :param number steem_power: Steem Power
+                    :param number vests: vesting shares"""
         if isinstance(sbd, Amount):
             sbd = Amount(sbd, steem_instance=self)
         elif isinstance(sbd, string_types):

--- a/beem/steem.py
+++ b/beem/steem.py
@@ -573,6 +573,9 @@ class Steem(object):
         return rshares
 
     def sbd_to_rshares(self, sbd, use_stored_data=True):
+        """ Obtain the r-shares from SBD
+
+        :param amount sbd: SBD"""
         if isinstance(sbd, Amount):
             sbd = Amount(sbd, steem_instance=self)
         elif isinstance(sbd, string_types):

--- a/beem/steem.py
+++ b/beem/steem.py
@@ -614,6 +614,18 @@ class Steem(object):
         vote_pct = used_power * STEEM_100_PERCENT / (60 * 60 * 24) / voting_power
         return int(math.copysign(vote_pct, rshares))
 
+    def sbd_to_vote_pct(self, sbd, steem_power=None, vests=None, voting_power=STEEM_100_PERCENT, use_stored_data=True):
+        if isinstance(sbd, Amount):
+            sbd = Amount(sbd, steem_instance=self)
+        elif isinstance(sbd, string_types):
+            sbd = Amount(sbd, steem_instance=self)
+        else:
+            sbd = Amount(sbd, 'SBD', steem_instance=self)
+        if sbd['symbol'] != 'SBD':
+            raise AssertionError()
+        rshares = self.sbd_to_rshares(sbd, use_stored_data=use_stored_data)
+        return self.rshares_to_vote_pct(rshares, steem_power=steem_power, vests=vests, voting_power=voting_power, use_stored_data=use_stored_data)
+
     def get_chain_properties(self, use_stored_data=True):
         """ Return witness elected chain properties
 

--- a/tests/beem/test_account.py
+++ b/tests/beem/test_account.py
@@ -584,3 +584,8 @@ class Testcases(unittest.TestCase):
         self.assertEqual(len(replies), 1)
         self.assertTrue(replies[0].is_comment())
         self.assertTrue(replies[0].depth > 0)
+
+    def test_get_vote_pct_for_SBD(self):
+        account = self.account
+        for vote_pwr in range(5, 100, 5):
+            self.assertTrue(9900 <= account.get_vote_pct_for_SBD(account.get_voting_value_SBD(voting_power=vote_pwr), voting_power=vote_pwr) <= 11000)

--- a/tests/beem/test_steem.py
+++ b/tests/beem/test_steem.py
@@ -588,6 +588,16 @@ class Testcases(unittest.TestCase):
         ret = stm.sp_to_sbd(sp)
         self.assertTrue(ret is not None)
 
+    def test_sbd_to_rshares(self):
+        stm = self.bts
+        test_values = [1, 10, 100, 1e3, 1e4, 1e5, 1e6, 1e7]
+        for v in test_values:
+            try:
+                sbd = round(stm.rshares_to_sbd(stm.sbd_to_rshares(v)), 5)
+            except ValueError: # Reward pool smaller than 1e7 SBD (e.g. caused by a very low steem price)
+                continue
+            self.assertEqual(sbd, v)
+
     def test_rshares_to_vote_pct(self):
         stm = self.bts
         sp = 1000


### PR DESCRIPTION
Should be self explanatory when looking at the documentation. Adds three new functions:
1. `get_vote_pct_for_SBD`
This function takes a number/string/Amount object as a parameter and returns the voting percentage needed to get a vote worth the earlier provided amount of SBD.
2. `sbd_to_vote_pct`
Very similar to `get_vote_pct_for_SBD`. Essentially does the same, but isn't part of the account module, but part of the steem module.
3. `sbd_to_rshares`
Returns an estimation of the number of required rshares for getting the value of the provided sbd.