### PR TITLE
beembase/objects: fix serialization of appbase trx

### DIFF
--- a/beembase/objects.py
+++ b/beembase/objects.py
@@ -51,8 +51,14 @@ class Amount(object):
             a = Array([String(d[0]), d[1], d[2]])
             self.str_repr = str(a.__str__())
         elif isinstance(d, dict) and "nai" in d:
+            self.asset = None
+            for c in known_chains:
+                for asset in known_chains[c]["chain_assets"]:
+                    if asset["asset"] == d["nai"]:
+                        self.asset = asset["symbol"]
+            if not self.asset:
+                raise ValueError("Unknown NAI, cannot resolve symbol")
             self.amount = d["amount"]
-            self.asset = d["nai"]
             self.precision = d["precision"]
             self.str_repr = json.dumps(d)
         else:
@@ -261,7 +267,14 @@ class CommentOptionExtensions(Static_variant):
 
     """
     def __init__(self, o):
-        type_id, data = o
+        if type(o) == dict and 'type' in o and 'value' in o:
+            if o['type'] == "comment_payout_beneficiaries":
+                type_id = 0
+            else:
+                type_id = ~0
+            data = o['value']
+        else:
+            type_id, data = o
         if type_id == 0:
             data = (Beneficiaries(data))
         else:


### PR DESCRIPTION
Refs #72

* serialization of appbase Amounts was incorrect (used `nai` number instead of `symbol` name)
* serialization of appbase beneficiary objects.

I'm pretty sure this doesn't fix the problem for custom chain params provided to the `Steem()` constructor but at least it should do for chains contained in `beemgraphenebase/chains.py`