### PR TITLE
Make vote rshare calculations HF20 ready

### DIFF
--- a/beem/steem.py
+++ b/beem/steem.py
@@ -580,7 +580,7 @@ class Steem(object):
         # calculate vote rshares
         rshares = int(math.copysign(vests * 1e6 * used_power / STEEM_100_PERCENT, vote_pct))
         if self.hardfork == 20:
-            rshares -= self.get_dust_threshold(use_stored_data=use_stored_data)
+            rshares -= math.copysign(self.get_dust_threshold(use_stored_data=use_stored_data), vote_pct)
         return rshares
 
     def sbd_to_rshares(self, sbd, not_broadcasted_vote=False, use_stored_data=True):
@@ -654,7 +654,7 @@ class Steem(object):
             vests = int(self.sp_to_vests(steem_power, use_stored_data=use_stored_data) * 1e6)
 
         if self.hardfork == 20:
-            rshares += self.get_dust_threshold(use_stored_data=use_stored_data)
+            rshares += math.copysign(self.get_dust_threshold(use_stored_data=use_stored_data), rshares)
 
         max_vote_denom = self._max_vote_denom(use_stored_data=use_stored_data)
 

--- a/beem/steem.py
+++ b/beem/steem.py
@@ -445,7 +445,10 @@ class Steem(object):
 
     def get_dust_threshold(self, use_stored_data=True):
         """Returns the vote dust threshold"""
-        props = self.get_config(use_stored_data=use_stored_data, replace_steemit_by_steem=True)
+        props = self.data['config']
+        if props is None:
+            self.refresh_data()
+            props = self.data['config']
         if props and 'STEEM_VOTE_DUST_THRESHOLD' in props:
             dust_threshold = props['STEEM_VOTE_DUST_THRESHOLD']
         else:

--- a/beem/steem.py
+++ b/beem/steem.py
@@ -740,6 +740,14 @@ class Steem(object):
             return self.get_network()
 
     @property
+    def hardfork(self):
+        if self.offline or self.rpc is None:
+            versions = known_chains['STEEM']['min_version']
+        else:
+            versions = self.get_blockchain_version()
+        return int(versions.split('.')[1])
+
+    @property
     def prefix(self):
         return self.chain_params["prefix"]
 

--- a/beem/steem.py
+++ b/beem/steem.py
@@ -579,6 +579,8 @@ class Steem(object):
         used_power = self._calc_resulting_vote(voting_power=voting_power, vote_pct=vote_pct, use_stored_data=use_stored_data)
         # calculate vote rshares
         rshares = int(math.copysign(vests * 1e6 * used_power / STEEM_100_PERCENT, vote_pct))
+        if self.hardfork == 20:
+            rshares -= self.get_dust_threshold(use_stored_data=use_stored_data)
         return rshares
 
     def sbd_to_rshares(self, sbd, not_broadcasted_vote=False, use_stored_data=True):
@@ -650,6 +652,9 @@ class Steem(object):
             raise ValueError("Either steem_power or vests has to be set. Not both!")
         if steem_power is not None:
             vests = int(self.sp_to_vests(steem_power, use_stored_data=use_stored_data) * 1e6)
+
+        if self.hardfork == 20:
+            rshares += self.get_dust_threshold(use_stored_data=use_stored_data)
 
         max_vote_denom = self._max_vote_denom(use_stored_data=use_stored_data)
 

--- a/beem/steem.py
+++ b/beem/steem.py
@@ -443,6 +443,15 @@ class Steem(object):
             blockchain_version = '0.0.0'
         return blockchain_version
 
+    def get_dust_threshold(self, use_stored_data=True):
+        """Returns the vote dust threshold"""
+        props = self.get_config(use_stored_data=use_stored_data, replace_steemit_by_steem=True)
+        if props and 'STEEM_VOTE_DUST_THRESHOLD' in props:
+            dust_threshold = props['STEEM_VOTE_DUST_THRESHOLD']
+        else:
+            dust_threshold = 0
+        return dust_threshold
+
     def rshares_to_sbd(self, rshares, not_broadcasted_vote=False, use_stored_data=True):
         """ Calculates the current SBD value of a vote
         """

--- a/beem/steem.py
+++ b/beem/steem.py
@@ -580,6 +580,8 @@ class Steem(object):
         # calculate vote rshares
         rshares = int(math.copysign(vests * 1e6 * used_power / STEEM_100_PERCENT, vote_pct))
         if self.hardfork == 20:
+            if abs(rshares) <= self.get_dust_threshold(use_stored_data=use_stored_data):
+                return 0
             rshares -= math.copysign(self.get_dust_threshold(use_stored_data=use_stored_data), vote_pct)
         return rshares
 


### PR DESCRIPTION
In HF20 every vote will get 50 000 000 rshares subtracted, and this PR makes these changes apply to calculations such as `vests_to_rshares`