### PR TITLE
Using generic asset symbols

### DIFF
--- a/beem/snapshot.py
+++ b/beem/snapshot.py
@@ -38,9 +38,9 @@ class AccountSnapshot(list):
     def reset(self):
         """ Resets the arrays not the stored account history
         """
-        self.own_vests = [Amount("0 VESTS", steem_instance=self.steem)]
-        self.own_steem = [Amount("0 STEEM", steem_instance=self.steem)]
-        self.own_sbd = [Amount("0 SBD", steem_instance=self.steem)]
+        self.own_vests = [Amount(0, self.steem.vests_symbol, steem_instance=self.steem)]
+        self.own_steem = [Amount(0, self.steem.steem_symbol, steem_instance=self.steem)]
+        self.own_sbd = [Amount(0, self.steem.steem_symbol, steem_instance=self.steem)]
         self.delegated_vests_in = [{}]
         self.delegated_vests_out = [{}]
         self.timestamps = [addTzInfo(datetime(1970, 1, 1, 0, 0, 0, 0))]
@@ -313,14 +313,14 @@ class AccountSnapshot(list):
             amount = Amount(op['amount'], steem_instance=self.steem)
             # print(op)
             if op['from'] == self.account["name"]:
-                if amount.symbol == "STEEM":
+                if amount.symbol == self.steem.steem_symbol:
                     self.update(ts, 0, 0, 0, amount * (-1), 0)
-                elif amount.symbol == "SBD":
+                elif amount.symbol == self.steem.sbd_symbol:
                     self.update(ts, 0, 0, 0, 0, amount * (-1))
             if op['to'] == self.account["name"]:
-                if amount.symbol == "STEEM":
+                if amount.symbol == self.steem.steem_symbol:
                     self.update(ts, 0, 0, 0, amount, 0)
-                elif amount.symbol == "SBD":
+                elif amount.symbol == self.steem.sbd_symbol:
                     self.update(ts, 0, 0, 0, 0, amount)
             # print(op, vests)
             # self.update(ts, vests, 0, 0)
@@ -330,14 +330,14 @@ class AccountSnapshot(list):
             current_pays = Amount(op["current_pays"], steem_instance=self.steem)
             open_pays = Amount(op["open_pays"], steem_instance=self.steem)
             if op["current_owner"] == self.account["name"]:
-                if current_pays.symbol == "STEEM":
+                if current_pays.symbol == self.steem.steem_symbol:
                     self.update(ts, 0, 0, 0, current_pays * (-1), open_pays)
-                elif current_pays.symbol == "SBD":
+                elif current_pays.symbol == self.steem.sbd_symbol:
                     self.update(ts, 0, 0, 0, open_pays, current_pays * (-1))
             if op["open_owner"] == self.account["name"]:
-                if current_pays.symbol == "STEEM":
+                if current_pays.symbol == self.steem.steem_symbol:
                     self.update(ts, 0, 0, 0, current_pays, open_pays * (-1))
-                elif current_pays.symbol == "SBD":
+                elif current_pays.symbol == self.steem.sbd_symbol:
                     self.update(ts, 0, 0, 0, open_pays * (-1), current_pays)
             # print(op)
             return

--- a/beem/witness.py
+++ b/beem/witness.py
@@ -117,15 +117,16 @@ class Witness(BlockchainObject):
 
     def feed_publish(self,
                      base,
-                     quote="1.000 STEEM",
+                     quote=None,
                      account=None):
         """ Publish a feed price as a witness.
             :param float base: USD Price of STEEM in SBD (implied price)
-            :param float quote: (optional) Quote Price. Should be 1.000, unless
+            :param float quote: (optional) Quote Price. Should be 1.000 (default), unless
             we are adjusting the feed to support the peg.
             :param str account: (optional) the source account for the transfer
             if not self["owner"]
         """
+        quote = quote if quote is not None else "1.000 %s" % (self.steem.symbol)
         if not account:
             account = self["owner"]
         if not account:
@@ -137,18 +138,18 @@ class Witness(BlockchainObject):
         elif isinstance(base, string_types):
             base = Amount(base, steem_instance=self.steem)
         else:
-            base = Amount(base, "SBD", steem_instance=self.steem)
+            base = Amount(base, self.steem.sbd_symbol, steem_instance=self.steem)
 
         if isinstance(quote, Amount):
             quote = Amount(quote, steem_instance=self.steem)
         elif isinstance(quote, string_types):
             quote = Amount(quote, steem_instance=self.steem)
         else:
-            quote = Amount(quote, "STEEM", steem_instance=self.steem)
+            quote = Amount(quote, self.steem.steem_symbol, steem_instance=self.steem)
 
-        if not base.symbol == "SBD":
+        if not base.symbol == self.steem.sbd_symbol:
             raise AssertionError()
-        if not quote.symbol == "STEEM":
+        if not quote.symbol == self.steem.steem_symbol:
             raise AssertionError()
 
         op = operations.Feed_publish(

--- a/beembase/objects.py
+++ b/beembase/objects.py
@@ -27,7 +27,7 @@ default_prefix = "STM"
 
 @python_2_unicode_compatible
 class Amount(object):
-    def __init__(self, d, prefix="STM"):
+    def __init__(self, d, prefix=default_prefix):
         if isinstance(d, string_types):
             self.amount, self.symbol = d.strip().split(" ")
             self.precision = None
@@ -164,8 +164,9 @@ class WitnessProps(GrapheneObject):
         else:
             if len(args) == 1 and len(kwargs) == 0:
                 kwargs = args[0]
+            prefix = kwargs.get("prefix", default_prefix)
             super(WitnessProps, self).__init__(OrderedDict([
-                ('account_creation_fee', Amount(kwargs["account_creation_fee"])),
+                ('account_creation_fee', Amount(kwargs["account_creation_fee"], prefix=prefix)),
                 ('maximum_block_size', Uint32(kwargs["maximum_block_size"])),
                 ('sbd_interest_rate', Uint16(kwargs["sbd_interest_rate"])),
             ]))
@@ -178,9 +179,10 @@ class Price(GrapheneObject):
         else:
             if len(args) == 1 and len(kwargs) == 0:
                 kwargs = args[0]
+            prefix = kwargs.get("prefix", default_prefix)
             super(Price, self).__init__(OrderedDict([
-                ('base', Amount(kwargs["base"])),
-                ('quote', Amount(kwargs["quote"]))
+                ('base', Amount(kwargs["base"], prefix=prefix)),
+                ('quote', Amount(kwargs["quote"], prefix=prefix))
             ]))
 
 
@@ -238,10 +240,11 @@ class ExchangeRate(GrapheneObject):
             if len(args) == 1 and len(kwargs) == 0:
                 kwargs = args[0]
 
+            prefix = kwargs.get("prefix", default_prefix)
             super(ExchangeRate, self).__init__(
                 OrderedDict([
-                    ('base', Amount(kwargs["base"])),
-                    ('quote', Amount(kwargs["quote"])),
+                    ('base', Amount(kwargs["base"], prefix=prefix)),
+                    ('quote', Amount(kwargs["quote"], prefix=prefix)),
                 ]))
 
 

--- a/beembase/operations.py
+++ b/beembase/operations.py
@@ -64,7 +64,7 @@ class Transfer(GrapheneObject):
         super(Transfer, self).__init__(OrderedDict([
             ('from', String(kwargs["from"])),
             ('to', String(kwargs["to"])),
-            ('amount', Amount(kwargs["amount"])),
+            ('amount', Amount(kwargs["amount"], prefix=prefix)),
             ('memo', memo),
         ]))
 
@@ -89,10 +89,11 @@ class Transfer_to_vesting(GrapheneObject):
             return
         if len(args) == 1 and len(kwargs) == 0:
             kwargs = args[0]
+        prefix = kwargs.get("prefix", default_prefix)
         super(Transfer_to_vesting, self).__init__(OrderedDict([
             ('from', String(kwargs["from"])),
             ('to', String(kwargs["to"])),
-            ('amount', Amount(kwargs["amount"])),
+            ('amount', Amount(kwargs["amount"], prefix=prefix)),
         ]))
 
 
@@ -102,9 +103,10 @@ class Withdraw_vesting(GrapheneObject):
             return
         if len(args) == 1 and len(kwargs) == 0:
             kwargs = args[0]
+        prefix = kwargs.get("prefix", default_prefix)
         super(Withdraw_vesting, self).__init__(OrderedDict([
             ('account', String(kwargs["account"])),
-            ('vesting_shares', Amount(kwargs["vesting_shares"])),
+            ('vesting_shares', Amount(kwargs["vesting_shares"], prefix=prefix)),
         ]))
 
 
@@ -190,7 +192,7 @@ class Account_create(GrapheneObject):
                 meta = kwargs["json_metadata"]
 
         super(Account_create, self).__init__(OrderedDict([
-            ('fee', Amount(kwargs["fee"])),
+            ('fee', Amount(kwargs["fee"], prefix=prefix)),
             ('creator', String(kwargs["creator"])),
             ('new_account_name', String(kwargs["new_account_name"])),
             ('owner', Permission(kwargs["owner"], prefix=prefix)),
@@ -221,8 +223,8 @@ class Account_create_with_delegation(GrapheneObject):
                 meta = kwargs["json_metadata"]
 
         super(Account_create_with_delegation, self).__init__(OrderedDict([
-            ('fee', Amount(kwargs["fee"])),
-            ('delegation', Amount(kwargs["delegation"])),
+            ('fee', Amount(kwargs["fee"], prefix=prefix)),
+            ('delegation', Amount(kwargs["delegation"], prefix=prefix)),
             ('creator', String(kwargs["creator"])),
             ('new_account_name', String(kwargs["new_account_name"])),
             ('owner', Permission(kwargs["owner"], prefix=prefix)),
@@ -302,10 +304,12 @@ class Witness_set_properties(GrapheneObject):
             elif isinstance(k[1], int) and k[0] in ["sbd_interest_rate"]:
                 props[k[0]] = (hexlify(Uint16(k[1]).__bytes__())).decode()
             elif not isinstance(k[1], str) and k[0] in ["account_creation_fee"]:
-                props[k[0]] = (hexlify(Amount(k[1]).__bytes__())).decode()
+                props[k[0]] = (hexlify(Amount(k[1], prefix=prefix).__bytes__())).decode()
             elif not is_hex and isinstance(k[1], str) and k[0] in ["account_creation_fee"]:
-                props[k[0]] = (hexlify(Amount(k[1]).__bytes__())).decode()
+                props[k[0]] = (hexlify(Amount(k[1], prefix=prefix).__bytes__())).decode()
             elif not isinstance(k[1], str) and k[0] in ["sbd_exchange_rate"]:
+                if 'prefix' not in k[1]:
+                    k[1]['prefix'] = prefix
                 props[k[0]] = (hexlify(ExchangeRate(k[1]).__bytes__())).decode()
             elif not is_hex and k[0] in ["url"]:
                 props[k[0]] = (hexlify(String(k[1]).__bytes__())).decode()
@@ -341,13 +345,15 @@ class Witness_update(GrapheneObject):
         else:
             block_signing_key = PublicKey(
                 prefix + "1111111111111111111111111111111114T1Anm", prefix=prefix)
+        if 'prefix' not in kwargs['props']:
+            kwargs['props']['prefix'] = prefix
 
         super(Witness_update, self).__init__(OrderedDict([
             ('owner', String(kwargs["owner"])),
             ('url', String(kwargs["url"])),
             ('block_signing_key', block_signing_key),
             ('props', WitnessProps(kwargs["props"])),
-            ('fee', Amount(kwargs["fee"])),
+            ('fee', Amount(kwargs["fee"], prefix=prefix)),
         ]))
 
 
@@ -410,6 +416,7 @@ class Comment_options(GrapheneObject):
             return
         if len(args) == 1 and len(kwargs) == 0:
             kwargs = args[0]
+        prefix = kwargs.get("prefix", default_prefix)
 
         # handle beneficiaries
         if "beneficiaries" in kwargs and kwargs['beneficiaries']:
@@ -424,7 +431,7 @@ class Comment_options(GrapheneObject):
                 ('author', String(kwargs["author"])),
                 ('permlink', String(kwargs["permlink"])),
                 ('max_accepted_payout',
-                 Amount(kwargs["max_accepted_payout"])),
+                 Amount(kwargs["max_accepted_payout"], prefix=prefix)),
                 ('percent_steem_dollars',
                  Uint16(int(kwargs["percent_steem_dollars"]))),
                 ('allow_votes', Bool(bool(kwargs["allow_votes"]))),
@@ -453,6 +460,9 @@ class Feed_publish(GrapheneObject):
             return
         if len(args) == 1 and len(kwargs) == 0:
             kwargs = args[0]
+        prefix = kwargs.get("prefix", default_prefix)
+        if 'prefix' not in kwargs['exchange_rate']:
+            kwargs['exchange_rate']['prefix'] = prefix
         super(Feed_publish, self).__init__(
             OrderedDict([
                 ('publisher', String(kwargs["publisher"])),
@@ -466,11 +476,12 @@ class Convert(GrapheneObject):
             return
         if len(args) == 1 and len(kwargs) == 0:
             kwargs = args[0]
+        prefix = kwargs.get("prefix", default_prefix)
         super(Convert, self).__init__(
             OrderedDict([
                 ('owner', String(kwargs["owner"])),
                 ('requestid', Uint32(kwargs["requestid"])),
-                ('amount', Amount(kwargs["amount"])),
+                ('amount', Amount(kwargs["amount"], prefix=prefix)),
             ]))
 
 
@@ -508,10 +519,11 @@ class Claim_account(GrapheneObject):
             return
         if len(args) == 1 and len(kwargs) == 0:
             kwargs = args[0]
+        prefix = kwargs.get("prefix", default_prefix)
         super(Claim_account, self).__init__(
             OrderedDict([
                 ('creator', String(kwargs["creator"])),
-                ('fee', Amount(kwargs["fee"])),
+                ('fee', Amount(kwargs["fee"], prefix=prefix)),
                 ('extensions', Array([])),
             ]))
 
@@ -553,11 +565,12 @@ class Delegate_vesting_shares(GrapheneObject):
             return
         if len(args) == 1 and len(kwargs) == 0:
             kwargs = args[0]
+        prefix = kwargs.get("prefix", default_prefix)
         super(Delegate_vesting_shares, self).__init__(
             OrderedDict([
                 ('delegator', String(kwargs["delegator"])),
                 ('delegatee', String(kwargs["delegatee"])),
-                ('vesting_shares', Amount(kwargs["vesting_shares"])),
+                ('vesting_shares', Amount(kwargs["vesting_shares"], prefix=prefix)),
             ]))
 
 
@@ -567,12 +580,13 @@ class Limit_order_create(GrapheneObject):
             return
         if len(args) == 1 and len(kwargs) == 0:
             kwargs = args[0]
+        prefix = kwargs.get("prefix", default_prefix)
         super(Limit_order_create, self).__init__(
             OrderedDict([
                 ('owner', String(kwargs["owner"])),
                 ('orderid', Uint32(kwargs["orderid"])),
-                ('amount_to_sell', Amount(kwargs["amount_to_sell"])),
-                ('min_to_receive', Amount(kwargs["min_to_receive"])),
+                ('amount_to_sell', Amount(kwargs["amount_to_sell"], prefix=prefix)),
+                ('min_to_receive', Amount(kwargs["min_to_receive"], prefix=prefix)),
                 ('fill_or_kill', Bool(kwargs["fill_or_kill"])),
                 ('expiration', PointInTime(kwargs["expiration"])),
             ]))
@@ -584,11 +598,14 @@ class Limit_order_create2(GrapheneObject):
             return
         if len(args) == 1 and len(kwargs) == 0:
             kwargs = args[0]
+        prefix = kwargs.get("prefix", default_prefix)
+        if 'prefix' not in kwargs['exchange_rate']:
+            kwargs['exchange_rate']['prefix'] = prefix
         super(Limit_order_create2, self).__init__(
             OrderedDict([
                 ('owner', String(kwargs["owner"])),
                 ('orderid', Uint32(kwargs["orderid"])),
-                ('amount_to_sell', Amount(kwargs["amount_to_sell"])),
+                ('amount_to_sell', Amount(kwargs["amount_to_sell"], prefix=prefix)),
                 ('fill_or_kill', Bool(kwargs["fill_or_kill"])),
                 ('exchange_rate', ExchangeRate(kwargs["exchange_rate"])),
                 ('expiration', PointInTime(kwargs["expiration"])),
@@ -615,6 +632,7 @@ class Transfer_from_savings(GrapheneObject):
             return
         if len(args) == 1 and len(kwargs) == 0:
             kwargs = args[0]
+        prefix = kwargs.get("prefix", default_prefix)
         if "memo" not in kwargs:
             kwargs["memo"] = ""
 
@@ -623,7 +641,7 @@ class Transfer_from_savings(GrapheneObject):
                 ('from', String(kwargs["from"])),
                 ('request_id', Uint32(kwargs["request_id"])),
                 ('to', String(kwargs["to"])),
-                ('amount', Amount(kwargs["amount"])),
+                ('amount', Amount(kwargs["amount"], prefix=prefix)),
                 ('memo', String(kwargs["memo"])),
             ]))
 
@@ -647,12 +665,13 @@ class Claim_reward_balance(GrapheneObject):
             return
         if len(args) == 1 and len(kwargs) == 0:
             kwargs = args[0]
+        prefix = kwargs.get("prefix", default_prefix)
         super(Claim_reward_balance, self).__init__(
             OrderedDict([
                 ('account', String(kwargs["account"])),
-                ('reward_steem', Amount(kwargs["reward_steem"])),
-                ('reward_sbd', Amount(kwargs["reward_sbd"])),
-                ('reward_vests', Amount(kwargs["reward_vests"])),
+                ('reward_steem', Amount(kwargs["reward_steem"], prefix=prefix)),
+                ('reward_sbd', Amount(kwargs["reward_sbd"], prefix=prefix)),
+                ('reward_vests', Amount(kwargs["reward_vests"], prefix=prefix)),
             ]))
 
 
@@ -662,13 +681,14 @@ class Transfer_to_savings(GrapheneObject):
             return
         if len(args) == 1 and len(kwargs) == 0:
             kwargs = args[0]
+        prefix = kwargs.get("prefix", default_prefix)
         if "memo" not in kwargs:
             kwargs["memo"] = ""
         super(Transfer_to_savings, self).__init__(
             OrderedDict([
                 ('from', String(kwargs["from"])),
                 ('to', String(kwargs["to"])),
-                ('amount', Amount(kwargs["amount"])),
+                ('amount', Amount(kwargs["amount"], prefix=prefix)),
                 ('memo', String(kwargs["memo"])),
             ]))
 
@@ -714,6 +734,7 @@ class Escrow_transfer(GrapheneObject):
             return
         if len(args) == 1 and len(kwargs) == 0:
             kwargs = args[0]
+        prefix = kwargs.get("prefix", default_prefix)
         meta = ""
         if "json_meta" in kwargs and kwargs["json_meta"]:
             if (isinstance(kwargs["json_meta"], dict) or isinstance(kwargs["json_meta"], list)):
@@ -726,9 +747,9 @@ class Escrow_transfer(GrapheneObject):
                 ('to', String(kwargs["to"])),
                 ('agent', String(kwargs["agent"])),
                 ('escrow_id', Uint32(kwargs["escrow_id"])),
-                ('sbd_amount', Amount(kwargs["sbd_amount"])),
-                ('steem_amount', Amount(kwargs["steem_amount"])),
-                ('fee', Amount(kwargs["fee"])),
+                ('sbd_amount', Amount(kwargs["sbd_amount"], prefix=prefix)),
+                ('steem_amount', Amount(kwargs["steem_amount"], prefix=prefix)),
+                ('fee', Amount(kwargs["fee"], prefix=prefix)),
                 ('ratification_deadline', PointInTime(kwargs["ratification_deadline"])),
                 ('escrow_expiration', PointInTime(kwargs["escrow_expiration"])),
                 ('json_meta', String(meta)),
@@ -756,14 +777,15 @@ class Escrow_release(GrapheneObject):
             return
         if len(args) == 1 and len(kwargs) == 0:
             kwargs = args[0]
+        prefix = kwargs.get("prefix", default_prefix)
         super(Escrow_release, self).__init__(
             OrderedDict([
                 ('from', String(kwargs["from"])),
                 ('to', String(kwargs["to"])),
                 ('who', String(kwargs["who"])),
                 ('escrow_id', Uint32(kwargs["escrow_id"])),
-                ('sbd_amount', Amount(kwargs["sbd_amount"])),
-                ('steem_amount', Amount(kwargs["steem_amount"])),
+                ('sbd_amount', Amount(kwargs["sbd_amount"], prefix=prefix)),
+                ('steem_amount', Amount(kwargs["steem_amount"], prefix=prefix)),
             ]))
 
 


### PR DESCRIPTION
These commits introduce `steem.steem_symbol`, `steem.sbd_symbol` and `steem.vests_symbol` as generic asset symbol names to improve the compatibility of beem with the Steemit testnet and other/third-party chains where the asset symbols are different to "STEEM", "SBD" or "VESTS".
The usage of the generic symbols is applied to various beem modules.

Changes in `beembase/operations.py` and `beembase/objects.py` propagate the corresponding prefix to the underlying objects for proper serialization also with the non-default chain parameters.