### PR TITLE
Fix get_discussions infinite cycle when discussions are empty

### DIFF
--- a/beem/discussions.py
+++ b/beem/discussions.py
@@ -151,6 +151,9 @@ class Discussions(object):
             elif discussion_type == "tags":
                 dd = Trending_tags(discussion_query, steem_instance=self.steem, lazy=self.lazy)
 
+            if not dd:
+                return
+
             for d in dd:
                 double_result = False
                 if discussion_type == "tags":


### PR DESCRIPTION
Fixes #97 

- return if discussions are empty