### PR TITLE
block.py: handle .block_num for get_ops_in_block

### DIFF
--- a/beem/block.py
+++ b/beem/block.py
@@ -162,6 +162,8 @@ class Block(BlockchainObject):
         """Returns the block number"""
         if "block_id" in self:
             return int(self['block_id'][:8], base=16)
+        elif 'block' in self:
+            return int(self['block'])
         else:
             return None
 


### PR DESCRIPTION
Fixes #122 

The `get_block()` answer contains the `block_id` field, correctly parsed by Block.block_num here:
https://github.com/holgern/beem/blob/49a8db878bff1a503b2e9acc9cd38f337efe9ba5/beem/block.py#L163

The `get_ops_in_block()` answer, however, does not contain a `block_id` field but directly provides the block number via the 'block' field. By adding a check for the `block` field, both cases should be treated correctly and Blockchain.blocks() doesn't run into `int(None)` errors anymore here:
https://github.com/holgern/beem/blob/49a8db878bff1a503b2e9acc9cd38f337efe9ba5/beem/blockchain.py#L470