### PR TITLE
beempy: adding support for multisig-transactions

### DIFF
--- a/beem/cli.py
+++ b/beem/cli.py
@@ -1671,8 +1671,10 @@ def disapprovewitness(witness, account):
 
 @cli.command()
 @click.option('--file', '-i', help='Load transaction from file. If "-", read from stdin (defaults to "-")')
-@click.option('--outfile', '-o', help='Load transaction from file. If "-", read from stdin (defaults to "-")')
-def sign(file, outfile):
+@click.option('--outfile', '-o', help='Save transaction to file. If "-", write to stdout (defaults to "-")')
+@click.option('--pubkey', help='(Partially) sign the transaction with a defined key')
+@click.option('--no-reconstruct', help="Dont't reconstruct the provided transaction", is_flag=True, default=False)
+def sign(file, outfile, pubkey, no_reconstruct):
     """Sign a provided transaction with available and required keys"""
     stm = shared_steem_instance()
     if stm.rpc is not None:
@@ -1690,7 +1692,11 @@ def sign(file, outfile):
     else:
         tx = click.get_text_stream('stdin')
     tx = ast.literal_eval(tx)
-    tx = stm.sign(tx)
+    if pubkey:
+        wifs = stm.wallet.getPrivateKeyForPublicKey(pubkey)
+    else:
+        wifs = []
+    tx = stm.sign(tx, wifs=wifs, reconstruct_tx=(not no_reconstruct))
     tx = json.dumps(tx, indent=4)
     if outfile and outfile != "-":
         with open(outfile, 'w') as fp:

--- a/beem/steem.py
+++ b/beem/steem.py
@@ -950,7 +950,7 @@ class Steem(object):
             self.txbuffer.sign()
             return self.txbuffer.broadcast()
 
-    def sign(self, tx=None, wifs=[]):
+    def sign(self, tx=None, wifs=[], reconstruct_tx=True):
         """ Sign a provided transaction with the provided key(s)
 
             :param dict tx: The transaction to be signed and returned
@@ -958,14 +958,19 @@ class Steem(object):
                 a transaction. If not present, the keys will be loaded
                 from the wallet as defined in "missing_signatures" key
                 of the transactions.
+            :param bool recontruct_tx: update `expiration`, `ref_block_num`
+                and `ref_block_prefix` with current values. Set to `False`
+                for signing multi-sig transactions.
+
         """
         if tx:
             txbuffer = TransactionBuilder(tx, steem_instance=self)
         else:
             txbuffer = self.txbuffer
         txbuffer.appendWif(wifs)
-        txbuffer.appendMissingSignatures()
-        txbuffer.sign()
+        if not wifs:
+            txbuffer.appendMissingSignatures()
+        txbuffer.sign(reconstruct_tx=reconstruct_tx)
         return txbuffer.json()
 
     def broadcast(self, tx=None):


### PR DESCRIPTION
For multisig, specify the pubkey that should be used for signing:
`beempy sign --file [filename] --pubkey [STM...] --no-reconstruct
--outfile [outfile]`
`--no-reconstruct` makes sure that existing signatures as well as`expiration`, `ref_block_num` and `ref_block_prefix` are kept in the transaction.