### PR TITLE
fix empty block handling

### DIFF
--- a/beem/block.py
+++ b/beem/block.py
@@ -141,7 +141,9 @@ class Block(BlockchainObject):
                          'timestamp': ops[0]["timestamp"],
                          'operations': ops}
             else:
-                block = {}
+                block = {'block': self.identifier,
+                         'timestamp': "1970-01-01T00:00:00",
+                         'operations': []}
         else:
             if self.steem.rpc.get_use_appbase():
                 try:


### PR DESCRIPTION
Avoid BlockDoesNotExistsException on `blockchain.stream()` and `Block()` with `only_ops=True` on blocks without ops.
Fixes #149.

Returning a dict with the requested block number enables `blockchain.blocks()` to keep track of which blocks were handled already. Since there are no ops when this code branch is taken, the timestamp is irrelevant in this case.