### PR TITLE
fix issue with adding posting auth to new accounts

### DIFF
--- a/beem/steem.py
+++ b/beem/steem.py
@@ -1456,7 +1456,7 @@ class Steem(object):
                        'key_auths': active_key_authority,
                        "address_auths": [],
                        'weight_threshold': 1},
-            'posting': {'account_auths': active_accounts_authority,
+            'posting': {'account_auths': posting_accounts_authority,
                         'key_auths': posting_key_authority,
                         "address_auths": [],
                         'weight_threshold': 1},

--- a/tests/beem/test_steem.py
+++ b/tests/beem/test_steem.py
@@ -32,9 +32,9 @@ class Testcases(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.nodelist = NodeList()
-        cls.nodelist.update_nodes(steem_instance=Steem(node=cls.nodelist.get_nodes(exclude_limited=False), num_retries=10))
+        cls.nodelist.update_nodes(steem_instance=Steem(node=cls.nodelist.get_nodes(), num_retries=10))
         cls.bts = Steem(
-            node=cls.nodelist.get_nodes(exclude_limited=True),
+            node=cls.nodelist.get_nodes(),
             nobroadcast=True,
             unsigned=True,
             data_refresh_time_seconds=900,
@@ -87,7 +87,8 @@ class Testcases(unittest.TestCase):
             additional_active_keys=[format(key5.pubkey, core_unit)],
             additional_posting_keys=[format(key5.pubkey, core_unit)],
             additional_owner_accounts=["test1"],  # 1.2.0
-            additional_active_accounts=["test1"],
+            additional_active_accounts=["test2"],
+            additional_posting_accounts=["test3"],
             storekeys=False,
         )
         self.assertEqual(
@@ -103,7 +104,7 @@ class Testcases(unittest.TestCase):
             format(key5.pubkey, core_unit),
             [x[0] for x in op[role]["key_auths"]])
         self.assertIn(
-            "test1",
+            "test2",
             [x[0] for x in op[role]["account_auths"]])
         role = "posting"
         self.assertIn(
@@ -113,7 +114,7 @@ class Testcases(unittest.TestCase):
             format(key5.pubkey, core_unit),
             [x[0] for x in op[role]["key_auths"]])
         self.assertIn(
-            "test1",
+            "test3",
             [x[0] for x in op[role]["account_auths"]])
         role = "owner"
         self.assertIn(


### PR DESCRIPTION
There was a typo in the `create_account` function related to `posting_authority_accounts`. This PR fixes the typo and updates the tests to help smoke out an issue like it in the future.

I was unable to run the test with `exclude_limited` in the nodelist so I removed it. Let me know if you want to leave that there and I can put it back in.