### PR TITLE
Fixed bug when accessing Account().blog_history(limit=x)

### DIFF
--- a/beem/comment.py
+++ b/beem/comment.py
@@ -129,7 +129,7 @@ class Comment(BlockchainObject):
                 ]
                 for p in parse_int:
                     if p in vote and isinstance(vote.get(p), string_types):
-                        vote[p] = int(vote.get(p, "0"))
+                        vote[p] = vote.get(p, "0")
                 new_active_votes.append(vote)
             comment["active_votes"] = new_active_votes
         return comment


### PR DESCRIPTION
vote.get was returning a base 10 xx.xx type number that was throwing errors when being cast to an int.