### PR TITLE
one-time use private key

### DIFF
--- a/beem/transactionbuilder.py
+++ b/beem/transactionbuilder.py
@@ -304,6 +304,8 @@ class TransactionBuilder(dict):
             raise ValueError("Invalid TransactionBuilder Format")
 
         if not any(self.wifs):
+            # if no key found in the wallet, give a chance to enter it manually for a one-time use
+            print("The required private key can't be found in the wallet.")
             wif = getpass.getpass("Private key to sign: ")
             if wif == '':
                 raise MissingKeyError

--- a/beem/transactionbuilder.py
+++ b/beem/transactionbuilder.py
@@ -22,6 +22,7 @@ from .exceptions import (
     OfflineHasNoRPCException
 )
 from beem.instance import shared_steem_instance
+import getpass
 log = logging.getLogger(__name__)
 
 
@@ -303,7 +304,11 @@ class TransactionBuilder(dict):
             raise ValueError("Invalid TransactionBuilder Format")
 
         if not any(self.wifs):
-            raise MissingKeyError
+            wif = getpass.getpass("Private key to sign: ")
+            if wif == '':
+                raise MissingKeyError
+            else:
+                self.wifs.add(wif)
 
         signedtx.sign(self.wifs, chain=self.steem.chain_params)
         self["signatures"].extend(signedtx.json().get("signatures"))


### PR DESCRIPTION
Close #162 

Instead of MissingKeyError when the key can't be found in the wallet, users have the second chance to enter the private key for a one-time use.