### PR TITLE
improve permlink derivation

### DIFF
--- a/beem/steem.py
+++ b/beem/steem.py
@@ -31,7 +31,7 @@ from .exceptions import (
 from .wallet import Wallet
 from .steemconnect import SteemConnect
 from .transactionbuilder import TransactionBuilder
-from .utils import formatTime, resolve_authorperm, derive_permlink, remove_from_dict, addTzInfo, formatToTimeStamp
+from .utils import formatTime, resolve_authorperm, derive_permlink, sanitize_permlink, remove_from_dict, addTzInfo, formatToTimeStamp
 from beem.constants import STEEM_VOTE_REGENERATION_SECONDS, STEEM_100_PERCENT, STEEM_1_PERCENT, STEEM_RC_REGEN_TIME
 
 log = logging.getLogger(__name__)
@@ -1775,7 +1775,7 @@ class Steem(object):
             if not permlink:
                 permlink = derive_permlink(title, parent_permlink)
         elif category:
-            parent_permlink = derive_permlink(category)
+            parent_permlink = sanitize_permlink(category)
             parent_author = ""
             if not permlink:
                 permlink = derive_permlink(title)

--- a/tests/beem/test_steem.py
+++ b/tests/beem/test_steem.py
@@ -326,7 +326,7 @@ class Testcases(unittest.TestCase):
         op = tx["operations"][0][1]
         self.assertEqual(op["body"], "body")
         self.assertEqual(op["title"], "title")
-        self.assertEqual(op["permlink"], "title")
+        self.assertTrue(op["permlink"].startswith("title"))
         self.assertEqual(op["parent_author"], "")
         self.assertEqual(op["parent_permlink"], "a")
         json_metadata = json.loads(op["json_metadata"])

--- a/tests/beem/test_utils.py
+++ b/tests/beem/test_utils.py
@@ -65,11 +65,16 @@ class Testcases(unittest.TestCase):
         self.assertEqual(sanitize_permlink("[](){}|"), "")
 
     def test_derivePermlink(self):
-        self.assertEqual(derive_permlink("Hello World"), "hello-world")
-        self.assertEqual(derive_permlink("aAf_0.12"), "aaf-0-12")
-        self.assertEqual(derive_permlink("[](){}"), "")
+        self.assertTrue(derive_permlink("Hello World").startswith("hello-world"))
+        self.assertTrue(derive_permlink("aAf_0.12").startswith("aaf-0-12"))
+        title = "[](){}"
+        permlink = derive_permlink(title)
+        self.assertFalse(permlink.startswith("-"))
+        for char in title:
+            self.assertFalse(char in permlink)
         self.assertEqual(len(derive_permlink("", parent_permlink=256 * "a")), 256)
         self.assertEqual(len(derive_permlink("", parent_permlink=256 * "a", parent_author="test")), 256)
+        self.assertEqual(len(derive_permlink("a" * 1024)), 256)
 
     def test_patch(self):
         self.assertEqual(make_patch("aa", "ab"), '@@ -1 +1 @@\n-aa\n+ab\n')
@@ -123,7 +128,7 @@ class Testcases(unittest.TestCase):
         self.assertEqual(b, [{"account": "beembot", "weight": 7000}, {"account": "holger80", "weight": 3000}])
         t = ["holger80:30", "beembot"]
         b = derive_beneficiaries(t)
-        self.assertEqual(b, [{"account": "beembot", "weight": 7000}, {"account": "holger80", "weight": 3000}])        
+        self.assertEqual(b, [{"account": "beembot", "weight": 7000}, {"account": "holger80", "weight": 3000}])
 
     def test_derive_tags(self):
         t = "test1,test2"


### PR DESCRIPTION
* append timestamp also to root post permlinks to avoid overwriting existing
  posts with the same title (fixes #179)
* avoid root permlinks to exceed the maximum length
* refactoring reply permlinks