### PR TITLE
response format handling and minor other things

### DIFF
--- a/beem/account.py
+++ b/beem/account.py
@@ -3068,19 +3068,12 @@ class Account(BlockchainObject):
             query_limit = 100
             if limit is not None and reblogs:
                 query_limit = min(limit - post_count + 1, query_limit)
-            if not start_permlink:
-                # first iteration uses `get_blog`
-                results = self.get_blog(start_entry_id=start,
-                                        account=account,
-                                        limit=query_limit)
-            else:
-                # all following iterations use `get_discussions_by_blog`
-                from .discussions import Query, Discussions_by_blog
-                query = Query(start_author=start_author,
-                              start_permlink=start_permlink,
-                              limit=query_limit, tag=account['name'])
-                results = Discussions_by_blog(query,
-                                              steem_instance=self.steem)
+
+            from .discussions import Discussions_by_blog
+            query = {'start_author': start_author,
+                     'start_permlink':start_permlink,
+                     'limit': query_limit, 'tag': account['name']}
+            results = Discussions_by_blog(query, steem_instance=self.steem)
             if len(results) == 0 or (start_permlink and len(results) == 1):
                 return
             if start_permlink:
@@ -3137,10 +3130,10 @@ class Account(BlockchainObject):
             query_limit = 100
             if limit is not None:
                 query_limit = min(limit - comment_count + 1, query_limit)
-            from .discussions import Query, Discussions_by_comments
-            query = Query(start_author=account['name'],
-                          start_permlink=start_permlink,
-                          limit=query_limit, tag=account['name'])
+            from .discussions import Discussions_by_comments
+            query = {'start_author': account['name'],
+                     'start_permlink': start_permlink, 'limit':
+                     query_limit}
             results = Discussions_by_comments(query,
                                               steem_instance=self.steem)
             if len(results) == 0 or (start_permlink and len(results) == 1):
@@ -3210,10 +3203,11 @@ class Account(BlockchainObject):
             query_limit = 100
             if limit is not None:
                 query_limit = min(limit - reply_count + 1, query_limit)
-            from .discussions import Query, Replies_by_last_update
-            query = Query(start_parent_author=start_author,
-                          start_permlink=start_permlink,
-                          limit=query_limit)
+            from .discussions import Replies_by_last_update
+
+            query = {'start_author': start_author,
+                     'start_permlink': start_permlink, 'limit':
+                     query_limit}
             results = Replies_by_last_update(query,
                                              steem_instance=self.steem)
             if len(results) == 0 or (start_permlink and len(results) == 1):

--- a/beem/comment.py
+++ b/beem/comment.py
@@ -588,7 +588,9 @@ class Comment(BlockchainObject):
             return None
         self.steem.rpc.set_next_node_on_empty_reply(False)
         if self.steem.rpc.get_use_appbase():
-            content_replies = self.steem.rpc.get_content_replies({'author': post_author, 'permlink': post_permlink}, api="tags")['discussions']
+            content_replies = self.steem.rpc.get_content_replies({'author': post_author, 'permlink': post_permlink}, api="tags")
+            if 'discussions' in content_replies:
+                content_replies = content_replies['discussions']
         else:
             content_replies = self.steem.rpc.get_content_replies(post_author, post_permlink, api="tags")
         if raw_data:

--- a/beem/discussions.py
+++ b/beem/discussions.py
@@ -546,7 +546,9 @@ class Discussions_by_blog(list):
         self.steem = steem_instance or shared_steem_instance()
         self.steem.rpc.set_next_node_on_empty_reply(self.steem.rpc.get_use_appbase())
         if self.steem.rpc.get_use_appbase():
-            posts = self.steem.rpc.get_discussions_by_blog(discussion_query, api="tags")['discussions']
+            posts = self.steem.rpc.get_discussions_by_blog(discussion_query, api="tags")
+            if 'discussions' in posts:
+                posts = posts['discussions']  # inconsistent format across node types
         else:
             # limit = discussion_query["limit"]
             # account = discussion_query["tag"]
@@ -580,7 +582,9 @@ class Discussions_by_comments(list):
         self.steem = steem_instance or shared_steem_instance()
         self.steem.rpc.set_next_node_on_empty_reply(self.steem.rpc.get_use_appbase())
         if self.steem.rpc.get_use_appbase():
-            posts = self.steem.rpc.get_discussions_by_comments(discussion_query, api="tags")['discussions']
+            posts = self.steem.rpc.get_discussions_by_comments(discussion_query, api="tags")
+            if 'discussions' in posts:
+                posts = posts['discussions']  # inconsistent format across node types
         else:
             posts = self.steem.rpc.get_discussions_by_comments(discussion_query)
         super(Discussions_by_comments, self).__init__(
@@ -640,9 +644,12 @@ class Replies_by_last_update(list):
         self.steem = steem_instance or shared_steem_instance()
         self.steem.rpc.set_next_node_on_empty_reply(self.steem.rpc.get_use_appbase())
         if self.steem.rpc.get_use_appbase():
-            posts = self.steem.rpc.get_replies_by_last_update(discussion_query, api="tags")['discussions']
+            posts = self.steem.rpc.get_replies_by_last_update(discussion_query, api="tags")
+            if 'discussions' in posts:
+                posts = posts['discussions']
         else:
             posts = self.steem.rpc.get_replies_by_last_update(discussion_query["start_parent_author"], discussion_query["start_permlink"], discussion_query["limit"])
+
         super(Replies_by_last_update, self).__init__(
             [
                 Comment(x, lazy=lazy, steem_instance=self.steem)

--- a/beem/discussions.py
+++ b/beem/discussions.py
@@ -648,7 +648,7 @@ class Replies_by_last_update(list):
             if 'discussions' in posts:
                 posts = posts['discussions']
         else:
-            posts = self.steem.rpc.get_replies_by_last_update(discussion_query["start_parent_author"], discussion_query["start_permlink"], discussion_query["limit"])
+            posts = self.steem.rpc.get_replies_by_last_update(discussion_query["start_author"], discussion_query["start_permlink"], discussion_query["limit"])
 
         super(Replies_by_last_update, self).__init__(
             [

--- a/beem/snapshot.py
+++ b/beem/snapshot.py
@@ -350,12 +350,12 @@ class AccountSnapshot(list):
         elif op['type'] == "transfer_to_vesting":
             steem = Amount(op['amount'], steem_instance=self.steem)
             vests = self.steem.sp_to_vests(steem.amount, timestamp=ts)
-            if op['from'] == self.account["name"]:
-                self.update(ts, vests, 0, 0, steem * (-1), 0)
-            else:
-                self.update(ts, vests, 0, 0, 0, 0)
-            # print(op)
-            # print(op, vests)
+            if op['from'] == self.account["name"] and op['to'] == self.account["name"]:
+                self.update(ts, vests, 0, 0, steem * (-1), 0)  # power up from and to given account
+            elif op['from'] != self.account["name"] and op['to'] == self.account["name"]:
+                self.update(ts, vests, 0, 0, 0, 0)  # power up from another account
+            else:  # op['from'] == self.account["name"] and op['to'] != self.account["name"]
+                self.update(ts, 0, 0, 0, steem * (-1), 0)  # power up to another account
             return
 
         elif op['type'] == "fill_vesting_withdraw":

--- a/beem/steem.py
+++ b/beem/steem.py
@@ -271,10 +271,9 @@ class Steem(object):
         self.data["dynamic_global_properties"] = self.get_dynamic_global_properties(False)
         try:
             self.data['feed_history'] = self.get_feed_history(False)
-            self.data['get_feed_history'] = self.get_feed_history(False)
         except:
             self.data['feed_history'] = None
-            self.data['get_feed_history'] = None
+        self.data['get_feed_history'] = self.data['feed_history']
         try:
             self.data['hardfork_properties'] = self.get_hardfork_properties(False)
         except:


### PR DESCRIPTION
* Improving compatibility with various node formats, some have the data in `['discussions']` others directly - may need adjustments at more calls in discussions.py, but (mostly) works now for blog/comments/replies and comment.replies (see table below).
* fix parameters to reply_history
* Improve compatibility with condenser API (doesn't seem to like unused params supplied via `Query` - using dicts directly
* remove redundant API call for feed history in `Steem` constructor
* bugfix in snapshot/build_sp_arrayt for power-up to another account

| Node | Condenser | Call | Result |
| --- | --- | --- | --- |
| https://api.steemit.com | True | blog_history | pass |
| https://api.steemit.com | True | comment_history | pass |
| https://api.steemit.com | True | reply_history | pass |
| https://api.steemit.com | True | get_replies | pass |
| https://steemd.minnowsupportproject.org | True | blog_history | pass |
| https://steemd.minnowsupportproject.org | True | comment_history | pass |
| https://steemd.minnowsupportproject.org | True | reply_history | pass |
| https://steemd.minnowsupportproject.org | True | get_replies | pass |
| http://anyx.io | True | blog_history | pass |
| http://anyx.io | True | comment_history | pass |
| http://anyx.io | True | reply_history | pass |
| http://anyx.io | True | get_replies | pass |
| https://anyx.io | True | blog_history | pass |
| https://anyx.io | True | comment_history | pass |
| https://anyx.io | True | reply_history | pass |
| https://anyx.io | True | get_replies | pass |
| https://api.steem.house | True | blog_history | pass |
| https://api.steem.house | True | comment_history | pass |
| https://api.steem.house | True | reply_history | pass |
| https://api.steem.house | True | get_replies | pass |
| https://rpc.usesteem.com | True | blog_history | pass |
| https://rpc.usesteem.com | True | comment_history | pass |
| https://rpc.usesteem.com | True | reply_history | pass |
| https://rpc.usesteem.com | True | get_replies | pass |
| https://steemd.privex.io | True | blog_history | pass |
| https://steemd.privex.io | True | comment_history | pass |
| https://steemd.privex.io | True | reply_history | pass |
| https://steemd.privex.io | True | get_replies | pass |
| https://api.steemit.com | False | blog_history | pass |
| https://api.steemit.com | False | comment_history | pass |
| https://api.steemit.com | False | reply_history |  Method not found |
| https://api.steemit.com | False | get_replies | pass |
| https://steemd.minnowsupportproject.org | False | blog_history |  Could not find API tags_api |
| https://steemd.minnowsupportproject.org | False | comment_history |  Could not find API tags_api |
| https://steemd.minnowsupportproject.org | False | reply_history |  Could not find API tags_api |
| https://steemd.minnowsupportproject.org | False | get_replies |  Could not find API tags_api |
| http://anyx.io | False | blog_history | pass |
| http://anyx.io | False | comment_history | pass |
| http://anyx.io | False | reply_history | pass |
| http://anyx.io | False | get_replies | pass |
| https://anyx.io | False | blog_history | pass |
| https://anyx.io | False | comment_history | pass |
| https://anyx.io | False | reply_history | pass |
| https://anyx.io | False | get_replies | pass |
| https://api.steem.house | False | blog_history | pass |
| https://api.steem.house | False | comment_history | pass |
| https://api.steem.house | False | reply_history |  Method not found |
| https://api.steem.house | False | get_replies | pass |
| https://rpc.usesteem.com | False | blog_history | pass |
| https://rpc.usesteem.com | False | comment_history | pass |
| https://rpc.usesteem.com | False | reply_history | pass |
| https://rpc.usesteem.com | False | get_replies | pass |
| https://steemd.privex.io | False | blog_history | pass |
| https://steemd.privex.io | False | comment_history | pass |
| https://steemd.privex.io | False | reply_history |  Method not found |
| https://steemd.privex.io | False | get_replies | pass |
