### PR TITLE
a few more mods for Hive compatibility

### DIFF
--- a/beem/steem.py
+++ b/beem/steem.py
@@ -314,7 +314,7 @@ class Steem(object):
         except:
             reserve_ratio = {'id': 0, 'average_block_size': None,
                              'current_reserve_ratio': None,
-                             'max_virtual_bandwidth': None}            
+                             'max_virtual_bandwidth': None}
         return reserve_ratio
 
     def get_feed_history(self, use_stored_data=True):
@@ -482,9 +482,9 @@ class Steem(object):
         """Returns the RC costs based on the resource_count"""
         pools = self.get_resource_pool()
         params = self.get_resource_params()
-        config = self.get_config()
         dyn_param = self.get_dynamic_global_properties()
-        rc_regen = int(Amount(dyn_param["total_vesting_shares"], steem_instance=self)) / (STEEM_RC_REGEN_TIME / config["STEEM_BLOCK_INTERVAL"])
+        rc_regen = int(Amount(dyn_param["total_vesting_shares"], steem_instance=self)) / \
+            (STEEM_RC_REGEN_TIME / self.get_block_interval())
         total_cost = 0
         if rc_regen == 0:
             return total_cost

--- a/beemapi/rpcutils.py
+++ b/beemapi/rpcutils.py
@@ -20,6 +20,10 @@ def is_network_appbase_ready(props):
         return False
     elif "STEEM_BLOCKCHAIN_VERSION" in props:
         return True
+    elif "HIVE_BLOCKCHAIN_VERSION" in props:
+        return True
+    else:
+        return False
 
 
 def get_query(appbase, request_id, api_name, name, args):


### PR DESCRIPTION
* `beempy --node https://api.hive.blog claimaccount [accname]` led to `Could not find method get_resource_pool`, turned out the nodes accept `get_resource_pool` only in appbase format
* Hive was not detected as appbase-ready - added in rpcutils
* RC calculation used `STEEM_BLOCK_INTERVAL` - by switching to the existing `get_block_interval`, the same call also works with `HIVE_BLOCK_INTERVAL`