### PR TITLE
Snapshot update

### DIFF
--- a/beem/snapshot.py
+++ b/beem/snapshot.py
@@ -238,7 +238,7 @@ class AccountSnapshot(list):
             elif delegated_out['amount'] != 0:
                 # new or updated non-zero delegation
                 new_deleg[delegated_out['account']] = delegated_out['amount']
-
+                # TODO
                 # skip undelegations here, wait for 'return_vesting_delegation'
                 # del new_deleg[delegated_out['account']]
 
@@ -261,7 +261,6 @@ class AccountSnapshot(list):
             ts = parse_time(op['timestamp'])
             if start_timestamp is not None and start_timestamp > ts:
                 continue
-            # print(op)
             if op['type'] in exclude_ops:
                 continue
             if len(only_ops) > 0 and op['type'] not in only_ops:
@@ -276,7 +275,6 @@ class AccountSnapshot(list):
         if op['type'] == "account_create":
             fee_steem = Amount(op['fee'], steem_instance=self.steem).amount
             fee_vests = self.steem.sp_to_vests(Amount(op['fee'], steem_instance=self.steem).amount, timestamp=ts)
-            # print(fee_vests)
             if op['new_account_name'] == self.account["name"]:
                 self.update(ts, fee_vests, 0, 0)
                 return
@@ -304,7 +302,6 @@ class AccountSnapshot(list):
 
         elif op['type'] == "delegate_vesting_shares":
             vests = Amount(op['vesting_shares'], steem_instance=self.steem)
-            # print(op)
             if op['delegator'] == self.account["name"]:
                 delegation = {'account': op['delegatee'], 'amount': vests}
                 self.update(ts, 0, 0, delegation)
@@ -316,7 +313,6 @@ class AccountSnapshot(list):
 
         elif op['type'] == "transfer":
             amount = Amount(op['amount'], steem_instance=self.steem)
-            # print(op)
             if op['from'] == self.account["name"]:
                 if amount.symbol == self.steem.steem_symbol:
                     self.update(ts, 0, 0, 0, amount * (-1), 0)
@@ -327,8 +323,6 @@ class AccountSnapshot(list):
                     self.update(ts, 0, 0, 0, amount, 0)
                 elif amount.symbol == self.steem.sbd_symbol:
                     self.update(ts, 0, 0, 0, 0, amount)
-            # print(op, vests)
-            # self.update(ts, vests, 0, 0)
             return
 
         elif op['type'] == "fill_order":
@@ -344,7 +338,6 @@ class AccountSnapshot(list):
                     self.update(ts, 0, 0, 0, current_pays, open_pays * (-1))
                 elif current_pays.symbol == self.steem.sbd_symbol:
                     self.update(ts, 0, 0, 0, open_pays * (-1), current_pays)
-            # print(op)
             return
 
         elif op['type'] == "transfer_to_vesting":
@@ -359,7 +352,6 @@ class AccountSnapshot(list):
             return
 
         elif op['type'] == "fill_vesting_withdraw":
-            # print(op)
             vests = Amount(op['withdrawn'], steem_instance=self.steem)
             self.update(ts, vests * (-1), 0, 0)
             return
@@ -388,7 +380,6 @@ class AccountSnapshot(list):
 
         elif op['type'] == "author_reward":
             if "author_reward" in only_ops or enable_rewards:
-                # print(op)
                 vests = Amount(op['vesting_payout'], steem_instance=self.steem)
                 steem = Amount(op['steem_payout'], steem_instance=self.steem)
                 sbd = Amount(op['sbd_payout'], steem_instance=self.steem)
@@ -453,11 +444,6 @@ class AccountSnapshot(list):
                             'fill_convert_request', 'convert', 'request_account_recovery',
                             'update_proposal_votes']:
             return
-
-        # if "vests" in str(op).lower():
-        #     print(op)
-        # else:
-        # print(op)
 
     def build_sp_arrays(self):
         """ Builds the own_sp and eff_sp array"""

--- a/beem/snapshot.py
+++ b/beem/snapshot.py
@@ -450,7 +450,8 @@ class AccountSnapshot(list):
                             'limit_order_create', 'account_update',
                             'account_witness_proxy', 'limit_order_cancel', 'comment_options',
                             'delete_comment', 'interest', 'recover_account', 'pow',
-                            'fill_convert_request', 'convert', 'request_account_recovery']:
+                            'fill_convert_request', 'convert', 'request_account_recovery',
+                            'update_proposal_votes']:
             return
 
         # if "vests" in str(op).lower():

--- a/beem/snapshot.py
+++ b/beem/snapshot.py
@@ -558,6 +558,17 @@ class AccountSnapshot(list):
 
                 self.vp_timestamp.append(ts)
 
+        if self.account.get_voting_power() == 100:
+            self.vp.append(10000)
+            recharge_time = self.account.get_manabar_recharge_timedelta({"current_mana_pct": self.vp[-2] / 100})
+            self.vp_timestamp.append(self.vp_timestamp[-1] + recharge_time)
+
+        if self.account.get_downvoting_power() == 100:
+            self.downvote_vp.append(10000)
+            recharge_time = self.account.get_manabar_recharge_timedelta(
+                {"current_mana_pct": self.downvote_vp[-2] / 100})
+            self.downvote_vp_timestamp.append(self.vp_timestamp[-1] + recharge_time)
+
         self.vp.append(self.account.get_voting_power() * 100)
         self.downvote_vp.append(self.account.get_downvoting_power() * 100)
         self.downvote_vp_timestamp.append(datetime.utcnow())

--- a/beem/snapshot.py
+++ b/beem/snapshot.py
@@ -552,6 +552,9 @@ class AccountSnapshot(list):
 
                 self.vp_timestamp.append(ts)
 
+        self.vp.append(self.account.get_voting_power() / 100)
+        self.downvote_vp(self.account.get_downvoting_power() / 100)
+
     def build_curation_arrays(self, end_date=None, sum_days=7):
         """ Build curation arrays"""
         self.curation_per_1000_SP_timestamp = []

--- a/beem/snapshot.py
+++ b/beem/snapshot.py
@@ -189,7 +189,7 @@ class AccountSnapshot(list):
             self.in_vote_rep.append(int(v["reputation"]))
             self.in_vote_rshares.append(int(v["rshares"]))
         except:
-            print("Could not found: %s" % v)
+            print("Could not find: %s" % v)
             return
 
     def update(self, timestamp, own, delegated_in=None, delegated_out=None, steem=0, sbd=0):

--- a/beem/snapshot.py
+++ b/beem/snapshot.py
@@ -496,7 +496,11 @@ class AccountSnapshot(list):
                 if self.downvote_vp[-1] > STEEM_100_PERCENT:
                     self.downvote_vp[-1] = STEEM_100_PERCENT
                     recharge_time = self.account.get_manabar_recharge_timedelta({"current_mana_pct": self.downvote_vp[-2] / 100})
+                    # Add full downvote VP once fully charged
                     self.downvote_vp_timestamp.append(self.vp_timestamp[-1] + recharge_time)
+                    self.downvote_vp.append(STEEM_100_PERCENT)
+                    # Add full downvote VP just before new Vote
+                    self.downvote_vp_timestamp.append(ts-timedelta(seconds=1))
                     self.downvote_vp.append(STEEM_100_PERCENT)
 
                 self.downvote_vp[-1] -= self.steem._calc_resulting_vote(STEEM_100_PERCENT, weight) * 4
@@ -513,7 +517,11 @@ class AccountSnapshot(list):
                         self.vp[-1] = STEEM_100_PERCENT
                         recharge_time = self.account.get_manabar_recharge_timedelta(
                             {"current_mana_pct": self.vp[-2] / 100})
+                        # Add full VP once fully charged
                         self.vp_timestamp.append(self.vp_timestamp[-1] + recharge_time)
+                        self.vp.append(STEEM_100_PERCENT)
+                        # Add full VP just before new Vote
+                        self.vp_timestamp.append(ts-timedelta(seconds=1))
                         self.vp.append(STEEM_100_PERCENT)
                     self.vp[-1] += self.downvote_vp[-1] / 4
                     if self.vp[-1] < 0:
@@ -521,7 +529,6 @@ class AccountSnapshot(list):
 
                     self.vp_timestamp.append(ts)
                 self.downvote_vp_timestamp.append(ts)
-
 
             else:
                 self.vp.append(self.vp[-1])
@@ -533,7 +540,11 @@ class AccountSnapshot(list):
                 if self.vp[-1] > STEEM_100_PERCENT:
                     self.vp[-1] = STEEM_100_PERCENT
                     recharge_time = self.account.get_manabar_recharge_timedelta({"current_mana_pct": self.vp[-2] / 100})
+                    # Add full VP once fully charged
                     self.vp_timestamp.append(self.vp_timestamp[-1] + recharge_time)
+                    self.vp.append(STEEM_100_PERCENT)
+                    # Add full VP just before new Vote
+                    self.vp_timestamp.append(ts - timedelta(seconds=1))
                     self.vp.append(STEEM_100_PERCENT)
                 self.vp[-1] -= self.steem._calc_resulting_vote(self.vp[-1], weight)
                 if self.vp[-1] < 0:

--- a/beem/snapshot.py
+++ b/beem/snapshot.py
@@ -439,6 +439,12 @@ class AccountSnapshot(list):
                 self.update_in_vote(ts, weight, op)
             return
 
+        elif op['type'] == 'hardfork_hive':
+            vests = Amount(op['vests_converted'])
+            hbd = Amount(op['steem_transferred'])
+            hive = Amount(op['sbd_transferred'])
+            self.update(ts, vests * (-1), 0, 0, hive * (-1), hbd * (-1))
+
         elif op['type'] in ['comment', 'feed_publish', 'shutdown_witness',
                             'account_witness_vote', 'witness_update', 'custom_json',
                             'limit_order_create', 'account_update',

--- a/beembase/operationids.py
+++ b/beembase/operationids.py
@@ -71,7 +71,8 @@ ops = [
     'producer_reward',
     'clear_null_account_balance',
     'proposal_pay',
-    'sps_fund'
+    'sps_fund',
+    'hardfork_hive'
 ]
 operations = {o: ops.index(o) for o in ops}
 

--- a/beembase/operationids.py
+++ b/beembase/operationids.py
@@ -72,7 +72,8 @@ ops = [
     'clear_null_account_balance',
     'proposal_pay',
     'sps_fund',
-    'hardfork_hive'
+    'hardfork_hive',
+    'hardfork_hive_restore',
 ]
 operations = {o: ops.index(o) for o in ops}
 

--- a/examples/account_vp_over_time.py
+++ b/examples/account_vp_over_time.py
@@ -25,9 +25,12 @@ if __name__ == "__main__":
     acc_snapshot.build_vp_arrays()
     timestamps = acc_snapshot.vp_timestamp
     vp = acc_snapshot.vp
+    downvote_timestamps = acc_snapshot.downvote_vp_timestamp
+    downvote_vp = acc_snapshot.downvote_vp
     plt.figure(figsize=(12, 6))
     opts = {'linestyle': '-', 'marker': '.'}
     plt.plot_date(timestamps, vp, label="Voting power", **opts)
+    plt.plot_date(downvote_timestamps, downvote_vp, label='Downvote Power', **opts)
     plt.grid()
     plt.legend()
     plt.title("Voting power over time - @%s" % (account))

--- a/examples/account_vp_over_time.py
+++ b/examples/account_vp_over_time.py
@@ -28,9 +28,9 @@ if __name__ == "__main__":
     downvote_timestamps = acc_snapshot.downvote_vp_timestamp
     downvote_vp = acc_snapshot.downvote_vp
     plt.figure(figsize=(12, 6))
-    opts = {'linestyle': '-', 'marker': '.'}
-    plt.plot_date(timestamps, vp, label="Voting power", **opts)
-    plt.plot_date(downvote_timestamps, downvote_vp, label='Downvote Power', **opts)
+    opts = {'linestyle': '-', 'marker': ''}
+    plt.plot_date(timestamps, vp, label="Voting power", color='green', **opts)
+    plt.plot_date(downvote_timestamps, downvote_vp, label='Downvote Power', color='red', **opts)
     plt.grid()
     plt.legend()
     plt.title("Voting power over time - @%s" % (account))


### PR DESCRIPTION
This enables the snapshot module to work even after the steem/hive fork. In order to do that, I needed to ignore the update_proposal_votes operation, and add the hardfork_hive operation for those accounts that are on the blacklist for the hardfork.

I also improved how the vp_arrays are built, so that longer voting pauses don't cause the graph to look like VP slowly regenerated, and that they also include the downvote VP after the time HF21 went live. I was told that at HF21 Downvote Power started at 100%, but I'm not entirely sure on that.