### PR TITLE
blockchain.py: handle virtual ops batch streaming

### DIFF
--- a/beem/blockchain.py
+++ b/beem/blockchain.py
@@ -559,7 +559,10 @@ class Blockchain(object):
                                 continue
                             if self.blockchain.rpc.get_use_appbase():
                                 if only_virtual_ops:
-                                    block = block["ops"]
+                                    block = {'block': block[0]["block"],
+                                             'timestamp': block[0]["timestamp"],
+                                             'id': block[0]['block'],
+                                             'operations': block}
                                 else:
                                     block = block["block"]
                             block = Block(block, only_ops=only_ops, only_virtual_ops=only_virtual_ops, blockchain_instance=self.blockchain)


### PR DESCRIPTION
Hi, `blockchain.stream(max_batch_size=50, only_virtual_ops=True)` fails with
```
  File "/usr/local/lib/python3.6/site-packages/beem/blockchain.py", line 562, in blocks
    block = block["ops"]
TypeError: list indices must be integers or slices, not str
```
It requires both `max_batch_size` and `only_virtual_ops` enabled to fail.

According to the [API](https://developers.hive.io/apidefinitions/#condenser_api.get_ops_in_block) the call is expected to return a list of transactions, not a dict with `ops` key (anymore?). The attached PR works around this and the same scheme is used at [other occasions](https://github.com/holgern/beem/blob/76d7f1cae5ee1288f725e111d2e074dc9d7cf50a/beem/block.py#L146) as well.

Reproduce via
```python
from beem import Hive
from beem.blockchain import Blockchain
h = Hive()
b = Blockchain(blockchain_instance=h)
for op in b.stream(start=1234567, stop=1234765, max_batch_size=50,
                   only_virtual_ops=True):
    print(op)
```
Is this the right approach or does it make sense to change `Block` to also accept a list of transactions instead? Let me know what you think!