### PR TITLE
blockchain: get_account_reputations fix for first

### DIFF
--- a/tests/beem/test_blockchain.py
+++ b/tests/beem/test_blockchain.py
@@ -9,7 +9,7 @@ from beem import Steem
 from beem.blockchain import Blockchain
 from beem.exceptions import BlockWaitTimeExceeded
 from beem.block import Block
-from beem.instance import set_shared_steem_instance
+from beem.instance import set_shared_blockchain_instance
 from beembase.signedtransactions import Signed_Transaction
 from .nodes import get_hive_nodes, get_steem_nodes
 
@@ -25,18 +25,18 @@ class Testcases(unittest.TestCase):
             keys={"active": wif},
             num_retries=10
         )
-        b = Blockchain(steem_instance=cls.bts)
+        b = Blockchain(blockchain_instance=cls.bts)
         num = b.get_current_block_num()
         cls.start = num - 5
         cls.stop = num
 
         # from getpass import getpass
         # self.bts.wallet.unlock(getpass())
-        set_shared_steem_instance(cls.bts)
+        set_shared_blockchain_instance(cls.bts)
 
     def test_blockchain(self):
         bts = self.bts
-        b = Blockchain(steem_instance=bts)
+        b = Blockchain(blockchain_instance=bts)
         num = b.get_current_block_num()
         self.assertTrue(num > 0)
         self.assertTrue(isinstance(num, int))
@@ -51,10 +51,10 @@ class Testcases(unittest.TestCase):
 
     def test_estimate_block_num(self):
         bts = self.bts
-        b = Blockchain(steem_instance=bts)
+        b = Blockchain(blockchain_instance=bts)
         last_block = b.get_current_block()
         num = last_block.identifier
-        old_block = Block(num - 60, steem_instance=bts)
+        old_block = Block(num - 60, blockchain_instance=bts)
         date = old_block.time()
         est_block_num = b.get_estimated_block_num(date, accurate=False)
         self.assertTrue((est_block_num - (old_block.identifier)) < 10)
@@ -64,9 +64,14 @@ class Testcases(unittest.TestCase):
         self.assertTrue((est_block_num - (old_block.identifier)) < 2)
         est_block_num = b.get_estimated_block_num(date, estimateForwards=True, accurate=False)
 
+    def test_get_account_count(self):
+        b = Blockchain(blockchain_instance=self.bts)
+        num = b.get_account_count()
+        self.assertTrue(isinstance(num, int) and num > 0)
+
     def test_get_all_accounts(self):
         bts = self.bts
-        b = Blockchain(steem_instance=bts)
+        b = Blockchain(blockchain_instance=bts)
         accounts = []
         limit = 200
         for acc in b.get_all_accounts(steps=100, limit=limit):
@@ -76,7 +81,7 @@ class Testcases(unittest.TestCase):
 
     def test_awaitTX(self):
         bts = self.bts
-        b = Blockchain(steem_instance=bts)
+        b = Blockchain(blockchain_instance=bts)
         trans = {'ref_block_num': 3855, 'ref_block_prefix': 1730859721,
                  'expiration': '2018-03-09T06:21:06', 'operations': [],
                  'extensions': [], 'signatures':
@@ -91,7 +96,7 @@ class Testcases(unittest.TestCase):
         bts = self.bts
         start = self.start
         stop = self.stop
-        b = Blockchain(steem_instance=bts)
+        b = Blockchain(blockchain_instance=bts)
         ops_stream = []
         opNames = ["transfer", "vote"]
         for op in b.stream(opNames=opNames, start=start, stop=stop):
@@ -182,7 +187,7 @@ class Testcases(unittest.TestCase):
 
     def test_stream2(self):
         bts = self.bts
-        b = Blockchain(steem_instance=bts)
+        b = Blockchain(blockchain_instance=bts)
         stop_block = b.get_current_block_num()
         start_block = stop_block - 10
         ops_stream = []
@@ -192,7 +197,7 @@ class Testcases(unittest.TestCase):
 
     def test_wait_for_and_get_block(self):
         bts = self.bts
-        b = Blockchain(steem_instance=bts, max_block_wait_repetition=18)
+        b = Blockchain(blockchain_instance=bts, max_block_wait_repetition=18)
         start_num = b.get_current_block_num()
         blocknum = start_num
         last_fetched_block_num = None
@@ -202,7 +207,7 @@ class Testcases(unittest.TestCase):
             blocknum = last_fetched_block_num + 1
         self.assertEqual(last_fetched_block_num, start_num + 2)
 
-        b2 = Blockchain(steem_instance=bts, max_block_wait_repetition=1)
+        b2 = Blockchain(blockchain_instance=bts, max_block_wait_repetition=1)
         with self.assertRaises(
             BlockWaitTimeExceeded
         ):
@@ -213,7 +218,7 @@ class Testcases(unittest.TestCase):
 
     def test_hash_op(self):
         bts = self.bts
-        b = Blockchain(steem_instance=bts)
+        b = Blockchain(blockchain_instance=bts)
         op1 = {'type': 'vote_operation', 'value': {'voter': 'ubg', 'author': 'yesslife', 'permlink': 'steemit-sandwich-contest-week-25-2da-entry', 'weight': 100}}
         op2 = ['vote', {'voter': 'ubg', 'author': 'yesslife', 'permlink': 'steemit-sandwich-contest-week-25-2da-entry', 'weight': 100}]
         hash1 = b.hash_op(op1)
@@ -221,9 +226,33 @@ class Testcases(unittest.TestCase):
         self.assertEqual(hash1, hash2)
 
     def test_signing_appbase(self):
-        b = Blockchain(steem_instance=self.bts)
+        b = Blockchain(blockchain_instance=self.bts)
         st = None
         for block in b.blocks(start=25304468, stop=25304468):
             for trx in block.transactions:
                 st = Signed_Transaction(trx.copy())
         self.assertTrue(st is not None)
+
+    def test_get_account_reputations(self):
+        b = Blockchain(blockchain_instance=self.bts)
+        limit = 100  # get the first 100 account reputations
+        reps_limit = list(b.get_account_reputations(limit=limit))
+        self.assertTrue(len(reps_limit) == limit)
+        for rep in reps_limit:  # expect format {'name': [str], 'reputation': [int]}
+            self.assertTrue(isinstance(rep, dict))
+            self.assertTrue('name' in rep and 'reputation' in rep)
+            self.assertTrue(isinstance(rep['name'], str))
+            self.assertTrue(isinstance(rep['reputation'], int))
+
+        first = reps_limit[0]['name']
+        last = reps_limit[-1]['name']
+        # get the same account reputations via start/stop constraints
+        reps_constr = list(b.get_account_reputations(start=first, stop=last))
+        self.assertTrue(len(reps_constr) >= limit)
+        # The actual number of accounts may have increased and the
+        # reputation values may be different between the two API
+        # calls, but each account of the first call should be
+        # contained in the second as well
+        accounts = [rep['name'] for rep in reps_constr]
+        for rep in reps_limit:
+            self.assertTrue(rep['name'] in accounts)


### PR DESCRIPTION
`get_account_reputations` called with the `first` parameter set was skipping the first result also for the first request in the loop, effectively missing one result.

- only skip the first result for follow-up requests
- add test case for `get_account_reputations()`
- replace `steem_instance` with `blockchain_instance`
- add test case for `get_account_count()`