### PR TITLE
beempy witnessproperties: fix interest rate options

### DIFF
--- a/beem/cli.py
+++ b/beem/cli.py
@@ -419,7 +419,7 @@ def set(key, value):
     elif key == "use_condenser":
         stm.config["use_condenser"] = value in ["true", "True"]
     elif key == "use_tor":
-        stm.config["use_tor"] = value in ["true", "True"]        
+        stm.config["use_tor"] = value in ["true", "True"]
     else:
         print("wrong key")
 
@@ -2275,7 +2275,7 @@ def beneficiaries(authorperm, beneficiaries, export):
         account = stm.config["default_account"]
     if not unlock_wallet(stm):
         return
-    
+
     options = {"author": c["author"],
                "permlink": c["permlink"],
                "max_accepted_payout": c["max_accepted_payout"],
@@ -3682,7 +3682,7 @@ def witnesscreate(witness, pub_signing_key, maximum_block_size, account_creation
     if not unlock_wallet(stm):
         return
     if stm.is_hive and stm.hardfork >= 24:
-        
+
         props = {
             "account_creation_fee":
                 Amount("%.3f %s" % (float(account_creation_fee), stm.token_symbol), blockchain_instance=stm),
@@ -3699,7 +3699,7 @@ def witnesscreate(witness, pub_signing_key, maximum_block_size, account_creation
                 int(maximum_block_size),
             "sbd_interest_rate":
                 int(sbd_interest_rate * 100)
-        }        
+        }
 
     tx = stm.witness_update(pub_signing_key, url, props, account=witness)
     if stm.unsigned and stm.nobroadcast and stm.steemconnect is not None:
@@ -3739,9 +3739,9 @@ def witnessproperties(witness, wif, account_creation_fee, account_subsidy_budget
     if maximum_block_size is not None:
         props["maximum_block_size"] = int(maximum_block_size)
     if sbd_interest_rate is not None:
-        props["sbd_interest_rate"] = int(sbd_interest_rate * 100)
+        props["sbd_interest_rate"] = int(float(sbd_interest_rate) * 100)
     if hbd_interest_rate is not None:
-        props["hbd_interest_rate"] = int(hbd_interest_rate * 100)        
+        props["hbd_interest_rate"] = int(float(hbd_interest_rate) * 100)
     if new_signing_key is not None:
         props["new_signing_key"] = new_signing_key
     if url is not None:
@@ -3777,12 +3777,12 @@ def witnessfeed(witness, wif, base, quote, support_peg):
         use_hbd = True
         old_base = witness["hbd_exchange_rate"]["base"]
         old_quote = witness["hbd_exchange_rate"]["quote"]
-        last_published_price = Price(witness["hbd_exchange_rate"], blockchain_instance=stm)   
+        last_published_price = Price(witness["hbd_exchange_rate"], blockchain_instance=stm)
     else:
         old_base = witness["sbd_exchange_rate"]["base"]
         old_quote = witness["sbd_exchange_rate"]["quote"]
         last_published_price = Price(witness["sbd_exchange_rate"], blockchain_instance=stm)
-     
+
     steem_usd = None
     hive_usd = None
     print("Old price %.3f (base: %s, quote %s)" % (float(last_published_price), old_base, old_quote))
@@ -3825,7 +3825,7 @@ def witnessfeed(witness, wif, base, quote, support_peg):
         tx = stm.witness_set_properties(wif, witness["owner"], props)
     elif wif is not None:
         props = {"sbd_exchange_rate": new_price}
-        tx = stm.witness_set_properties(wif, witness["owner"], props)        
+        tx = stm.witness_set_properties(wif, witness["owner"], props)
     else:
         tx = witness.feed_publish(base, quote=quote)
     if stm.unsigned and stm.nobroadcast and stm.steemconnect is not None:
@@ -4247,7 +4247,7 @@ def rewards(accounts, only_sum, post, comment, curation, length, author, permlin
                         payout_STEEM = Amount(v["steem_payout"], blockchain_instance=stm)
                     else:
                         payout_SBD = Amount(v["hbd_payout"], blockchain_instance=stm)
-                        payout_STEEM = Amount(v["hive_payout"], blockchain_instance=stm)                        
+                        payout_STEEM = Amount(v["hive_payout"], blockchain_instance=stm)
                     sum_reward[0] += float(payout_SBD)
                     sum_reward[1] += float(payout_STEEM)
                     payout_SP = stm.vests_to_token_power(Amount(v["vesting_payout"], blockchain_instance=stm))


### PR DESCRIPTION
the previous `int(hbd_interest_rate * 100)` took the `hdb_interest_rate` as string a hundred times, leading to `struct.error: argument out of range`. casting to `float` first, plus a few whitespace removals...