### PR TITLE
WIP: Trying to fix claim_reward_balance for Blurt compatibility

### DIFF
--- a/beem/account.py
+++ b/beem/account.py
@@ -176,8 +176,10 @@ class Account(BlockchainObject):
             "reward_hbd_balance",            
             "reward_steem_balance",
             "reward_hive_balance",
+            "reward_blurt_balance",
             "reward_vesting_balance",
             "reward_vesting_steem",
+            "reward_vesting_blurt",
             "vesting_shares",
             "delegated_vesting_shares",
             "received_vesting_shares",
@@ -233,12 +235,14 @@ class Account(BlockchainObject):
             "savings_sbd_balance",
             "reward_sbd_balance",
             "reward_steem_balance",
+            "reward_blurt_balance",
             "hbd_balance",
             "savings_hbd_balance",
             "reward_hbd_balance",
             "reward_hive_balance",            
             "reward_vesting_balance",
             "reward_vesting_steem",
+            "reward_vesting_blurt",
             "vesting_shares",
             "delegated_vesting_shares",
             "received_vesting_shares",
@@ -1188,6 +1192,8 @@ class Account(BlockchainObject):
             amount_list = ["reward_steem_balance", "reward_sbd_balance", "reward_vesting_balance"]
         elif "reward_hive_balance" in self and "reward_hbd_balance" in self:
             amount_list = ["reward_hive_balance", "reward_hbd_balance", "reward_vesting_balance"]
+        elif "reward_blurt_balance" in self:
+            amount_list = ["reward_blurt_balance", "reward_vesting_balance"]
         else:
             amount_list = []
         rewards_amount = []
@@ -3117,12 +3123,13 @@ class Account(BlockchainObject):
         return amount
 
     def claim_reward_balance(self,
-                             reward_steem=0,
-                             reward_sbd=0,
-                             reward_hive=0,
-                             reward_hbd=0,                             
-                             reward_vests=0,
-                             account=None, **kwargs):
+                            reward_steem=0,
+                            reward_sbd=0,
+                            reward_hive=0,
+                            reward_hbd=0, 
+                            reward_blurt=0,                            
+                            reward_vests=0,
+                            account=None, **kwargs):
         """ Claim reward balances.
         By default, this will claim ``all`` outstanding balances. To bypass
         this behaviour, set desired claim amount by setting any of
@@ -3130,6 +3137,7 @@ class Account(BlockchainObject):
 
         :param str reward_steem: Amount of STEEM you would like to claim.
         :param str reward_hive: Amount of HIVE you would like to claim.
+        :param str reward_blurt: Amount of BLURT you would like to claim.
         :param str reward_sbd: Amount of SBD you would like to claim.
         :param str reward_hbd: Amount of HBD you would like to claim.
         :param str reward_vests: Amount of VESTS you would like to claim.
@@ -3147,16 +3155,18 @@ class Account(BlockchainObject):
         # if no values were set by user, claim all outstanding balances on
         # account
 
-        reward_token_amount = self._check_amount(reward_steem + reward_hive, self.blockchain.token_symbol)
+        reward_token_amount = self._check_amount(reward_steem + reward_hive + reward_blurt, self.blockchain.token_symbol)
         reward_backed_token_amount = self._check_amount(reward_sbd + reward_hbd, self.blockchain.backed_token_symbol)
         reward_vests_amount = self._check_amount(reward_vests, self.blockchain.vest_token_symbol)
 
         if self.blockchain.is_hive:
             reward_token = "reward_hive"
             reward_backed_token = "reward_hbd"
-        else:
+        elif self.blockchain.is_steem:
             reward_token = "reward_steem"
-            reward_backed_token = "reward_sbd"            
+            reward_backed_token = "reward_sbd"
+        else:
+            reward_token = "reward_blurt"
 
         if reward_token_amount.amount == 0 and reward_backed_token_amount.amount == 0 and reward_vests_amount.amount == 0:
             if len(account.balances["rewards"]) == 3:

--- a/beembase/operations.py
+++ b/beembase/operations.py
@@ -851,6 +851,13 @@ class Claim_reward_balance(GrapheneObject):
                     ('reward_hive', Amount(kwargs["reward_hive"], prefix=prefix, json_str=json_str)),
                     ('reward_vests', Amount(kwargs["reward_vests"], prefix=prefix)),
                 ]))
+        elif "reward_blurt" in kwargs:
+            super(Claim_reward_balance, self).__init__(
+                OrderedDict([
+                    ('account', String(kwargs["account"])),
+                    ('reward_blurt', Amount(kwargs["reward_blurt"], prefix=prefix)),
+                    ('reward_vests', Amount(kwargs["reward_vests"], prefix=prefix)),
+                ]))
         else:
             super(Claim_reward_balance, self).__init__(
                 OrderedDict([


### PR DESCRIPTION
I set out to try fixing the claim_reward_balance so that it would work on Blurt.
I started by fixing reward_balances.
That now works correctly. Example: 

```py
>>> a.reward_balances
[0.000 BLURT, 56.055241 VESTS]
```

Before, it would return an empty list.

Then I tried fixing the claim_reward_balance. I've managed to get it to build the transaction and broadcast it, but the RPC rejects the transaction saying that it's missing posting authority.

If I do it with `blurt.nobroadcast=True`, the returned transaction looks okay:

```py
>>> blurt.nobroadcast=True
>>> a.claim_reward_balance()
{'expiration': '2021-04-04T03:09:03', 'ref_block_num': 23150, 'ref_block_prefix': 3025359504, 'operations': [['claim_reward_balance', {'account': 'saboin', 'reward_blurt': '0.000 BLURT', 'reward_vests': '56.055241 VESTS'}]], 'extensions': [], 'signatures': ['1f29e691eefe2ca6ae93bc3c5477fe89480058fc9c2f1312b741b64ff3c98de2304cbf6daa5748d7900d88f685c6f62d8171520e4357050308ac2740e2ea205e5e'], 'trx_id': '8285c641085bb52d8aa175eb3bf4c147050a6535'}
```

But if I do it with `blurt.nobroadcast=False`, it gets rejected as if it's not signed correctly, and that's where I'm stuck. This part is a bit beyond my ability.

Here's the traceback if it can help point someone in the right direction:

```py
>>> blurt.nobroadcast=False
>>> a.claim_reward_balance()
Traceback (most recent call last):
** IDLE Internal Exception: 
  File "/Users/Saboin/Library/Python/3.8/lib/python/site-packages/beem-0.24.22-py3.8.egg/beemapi/noderpc.py", line 62, in rpcexec
    reply = super(NodeRPC, self).rpcexec(payload)
  File "/Users/Saboin/Library/Python/3.8/lib/python/site-packages/beem-0.24.22-py3.8.egg/beemapi/graphenerpc.py", line 457, in rpcexec
    raise RPCError(ret['error']['message'])
beemapi.exceptions.RPCError: missing required posting authority:Missing Posting Authority saboin

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<pyshell#79>", line 1, in <module>
    a.claim_reward_balance()
  File "/Users/Saboin/Library/Python/3.8/lib/python/site-packages/beem-0.24.22-py3.8.egg/beem/account.py", line 3197, in claim_reward_balance
    return self.blockchain.finalizeOp(op, account, "posting", **kwargs)
  File "/Users/Saboin/Library/Python/3.8/lib/python/site-packages/beem-0.24.22-py3.8.egg/beem/blockchaininstance.py", line 937, in finalizeOp
    ret = self.txbuffer.broadcast()
  File "/Users/Saboin/Library/Python/3.8/lib/python/site-packages/beem-0.24.22-py3.8.egg/beem/transactionbuilder.py", line 558, in broadcast
    raise e
  File "/Users/Saboin/Library/Python/3.8/lib/python/site-packages/beem-0.24.22-py3.8.egg/beem/transactionbuilder.py", line 553, in broadcast
    self.blockchain.rpc.broadcast_transaction(
beemapi.exceptions.UnhandledRPCError: missing required posting authority:Missing Posting Authority saboin
>>>
```
