### PR TITLE
Prioritize HIVE_CHAIN_ID property for the chain selection

### DIFF
--- a/beemapi/graphenerpc.py
+++ b/beemapi/graphenerpc.py
@@ -304,6 +304,8 @@ class GrapheneRPC(object):
         prefix = None
         symbols = []
         chain_assets = []
+        if 'HIVE_CHAIN_ID' in props and 'STEEM_CHAIN_ID' in props:
+            del props['STEEM_CHAIN_ID']
         for key in props:
             if key[-8:] == "CHAIN_ID":
                 chain_id = props[key]


### PR DESCRIPTION
when both `HIVE_CHAIN_ID` and `STEEM_CHAIN_ID` returns valid IDs, Hive should be selected as the preferred network.