### PR TITLE
Ignore OLD_CHAIN_ID which is present in 1.25.0 API nodes (renamed fro…

### DIFF
--- a/beemapi/graphenerpc.py
+++ b/beemapi/graphenerpc.py
@@ -306,6 +306,8 @@ class GrapheneRPC(object):
         chain_assets = []
         if 'HIVE_CHAIN_ID' in props and 'STEEM_CHAIN_ID' in props:
             del props['STEEM_CHAIN_ID']
+        if 'HIVE_CHAIN_ID' in props and 'OLD_CHAIN_ID' in props:
+            del props['OLD_CHAIN_ID']
         for key in props:
             if key[-8:] == "CHAIN_ID":
                 chain_id = props[key]


### PR DESCRIPTION
…m STEEM_CHAIN_ID)

when both `HIVE_CHAIN_ID` and `OLD_CHAIN_ID` returns valid IDs, Hive is selected as a network.